### PR TITLE
Add SCF issue 419 pipeline artifact example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The skill is generic — each project defines its own conventions for things lik
 
 See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples.
 
+## Examples
+
+- [`examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/`](./examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/) — a real pipeline artifact set for a public issue, including spec, design, and implementation-plan revisions plus their approved canonical artifacts.
+
 ## Current status
 
 CLIs:

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/README.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/README.md
@@ -1,0 +1,22 @@
+# Secure Custom Fields — Issue 419 Example
+
+This folder archives a real Radical Pipelines run for:
+
+- Repository: `WordPress/secure-custom-fields`
+- Issue: [#419](https://github.com/WordPress/secure-custom-fields/issues/419)
+- Task: `Experiment: Add Gutenberg-compatible custom field placeholders for post content.`
+- Pipeline slug: `issue-419-gutenberg-custom-field-placeholders`
+
+## What's included
+
+This example preserves the markdown artifacts produced during the pipeline:
+
+- spec drafts and reviews
+- design drafts and reviews
+- implementation plan and review
+- canonical promoted artifacts (`spec.md`, `design.md`, `implementation-plan.md`)
+
+## Notes
+
+- These files were copied from a local worktree after the public PR branch was cleaned, so private/public-repo-unfriendly `.pi` bootstrap files are intentionally not included here.
+- The implementation phase output itself lives in the Secure Custom Fields pull request, while this folder focuses on the inspectable planning artifacts.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-review-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-review-v1.md
@@ -1,0 +1,43 @@
+Decision: DENY
+
+Why
+- The design is strong overall and tracks the approved spec closely on render-time replacement, block scope, field-type allowlisting, silent failure, deactivation behavior, and a narrow frontend-only implementation path.
+- However, it is not yet implementation-ready because it leaves two security/behavior decisions materially unresolved in the “Open questions” section:
+  1. whether placeholder eligibility requires `allow_in_bindings` to be explicitly `true`, or only denies when it is explicitly `false`
+  2. the exact inline HTML allowlist, especially whether `span` is allowed and which attributes survive
+- Those are not minor follow-ups. They directly determine the trust boundary for “non-public” field exposure and the final sanitization contract. Phase 2 should lock those down, not defer them.
+- There is also one architecture realism gap: the design says the service should “instantiate during plugin bootstrap” and hook `render_block`, but it does not pin the registration point tightly enough to show that the callback will only exist in the intended frontend runtime and remain isolated from broader plugin behavior. The implementation path is likely straightforward, but the design should state where the class is loaded/bootstrapped and why that lifecycle is correct.
+
+Architecture notes
+- Good decisions:
+  - Using `render_block` with exact `core/paragraph` and `core/heading` checks is appropriately narrower than whole-string `the_content` replacement and aligns with the approved spec.
+  - The proposed regex `~\[\[([A-Za-z0-9_-]+)\]\]~` matches the approved token grammar and preserves malformed tokens literally.
+  - Reusing `get_field_object()` plus the `acf/prevent_access_to_unknown_fields` pattern is realistic in this codebase and consistent with existing shortcode security behavior.
+  - Local per-request caching keyed by post ID + field name is sensible and low risk.
+  - Explicitly sanitizing formatted values with a placeholder-specific `wp_kses()` policy instead of relying on generic escaped-HTML output is the right architectural direction for the spec’s inline-only HTML requirement.
+- Concerns to resolve:
+  - The `allow_in_bindings` rule must be deterministic. The codebase defaults legacy fields with missing `allow_in_bindings` to `true` in field settings UI behavior, while new fields default to `false`. The design currently recommends “deny only when explicitly false” but also leaves the stricter alternative open. That ambiguity changes which existing fields become placeholder-readable and therefore changes the security posture.
+  - The inline HTML contract must be fixed. “Suggested baseline” is too soft for implementation review. If `span` is included, the attribute list must be explicit. If it is excluded, say so. Similar clarity is needed for anchors (`href`, `target`, `rel`, possibly `title`).
+  - The bootstrap/lifecycle note should specify where the service is required and when hooks are attached, so implementers do not accidentally register behavior in contexts the spec intentionally excludes.
+
+Required changes
+1. Resolve the `allow_in_bindings` policy definitively.
+   - Choose one rule and remove the open question.
+   - The design must explicitly state the default behavior for legacy fields where `allow_in_bindings` is absent.
+   - It must justify that choice against the approved spec’s “sensitive/non-public” exclusion and backward-compatibility expectations.
+2. Replace the “suggested baseline” inline HTML allowlist with a final, explicit allowlist.
+   - State the exact allowed tags.
+   - State the exact allowed attributes per tag.
+   - Explicitly decide whether `span` is allowed; if yes, define its allowed attributes.
+   - Keep the policy aligned with the approved inline-only requirement.
+3. Tighten the bootstrap/registration section.
+   - Name the concrete file/class loading path.
+   - State when the service is instantiated and hooks are registered.
+   - Confirm the callback is intended to run only as part of frontend rendering logic and does not broaden the feature scope beyond the approved render path.
+4. Remove or close any remaining open questions that materially affect v1 security or output behavior.
+   - Questions about future extensibility can remain if clearly marked non-blocking.
+   - Questions that change eligibility or sanitization behavior cannot remain open in an implementation-ready design.
+
+Next version expected
+- `design-v2.md`
+- Expected outcome: same overall architecture, but with the field-publicity rule, sanitization contract, and bootstrap lifecycle fully specified and no blocking open questions remaining.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-review-v2.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-review-v2.md
@@ -1,0 +1,43 @@
+Decision: APPROVE
+
+Why
+- This revision closes the blocking gaps from `design-review-v1.md` and is now implementation-ready.
+- The design is traceable to the approved spec and makes concrete, testable decisions on the three boundaries that mattered most for phase 2:
+  - where replacement runs (`render_block` with strict runtime gating)
+  - which fields are eligible (explicit field-type allowlist plus explicit `allow_in_bindings` opt-in)
+  - which HTML survives (`wp_kses()` with a fixed inline-only tag/attribute allowlist)
+- The architecture is realistic for WordPress/Gutenberg and for this codebase specifically. It reuses existing SCF resolution and security patterns (`get_field_object()` and temporary `acf/prevent_access_to_unknown_fields` protection) without broadening existing template, REST, or block bindings behavior.
+- Security posture is appropriately conservative for a v1 experiment. Requiring `allow_in_bindings` to be explicitly present and truthy is stricter than the existing binding default behavior for some legacy fields, but it is deterministic, documented in the design, and aligned with the spec’s exclusion of sensitive/non-public values.
+- The sanitization contract is now explicit enough to implement and test without guesswork. Excluding `span`, classes, styles, IDs, data attributes, and event handlers keeps the output surface narrow and predictable.
+- Backward compatibility and deactivation behavior remain correct: saved content is untouched, unsupported contexts stay raw, and plugin deactivation reveals the original placeholder text.
+- Testing guidance is sufficiently complete for both PHP and E2E coverage.
+
+Architecture notes
+- Hooking `render_block` and then narrowing to `core/paragraph` and `core/heading` is the right choice for the approved v1 scope. It is more precise than whole-content `the_content` search/replace and avoids accidental support for unsupported block types.
+- The runtime gate is appropriately conservative:
+  - no admin
+  - no JSON request
+  - no feed
+  - singular only
+  - inside `the_content`
+  - in loop
+  - main query
+  - valid supported block
+  - `[[` substring present
+- The bootstrap section is now concrete enough for implementation review. Naming the include path, instantiation point, and single filter registration path removes ambiguity about lifecycle and scope.
+- The replacement/data flow is clear and efficient: scan only supported block HTML, dedupe placeholder names per block, resolve each once, and cache by post ID + field name including empty-string results.
+- The field-resolution path is realistic in this repository:
+  - strict field lookup against current post metadata
+  - temporary unknown-field access prevention
+  - explicit allowlist check
+  - explicit `allow_in_bindings` check
+  - scalar/non-empty enforcement
+- The final KSES allowlist is narrow and matches the spec’s inline-only requirement. The documented examples also make the intended stripping behavior clear for WYSIWYG values containing structural markup.
+- The remaining open questions are truly non-blocking future-scope items and do not weaken v1 implementation readiness.
+
+Required changes
+- None.
+
+Next version expected
+- No further phase-2 design revision required.
+- Proceed to phase 3 implementation plan based on `design-v2.md`.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-v1.md
@@ -1,0 +1,523 @@
+# Task
+
+Create a technical design for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Spec reference
+
+- Approved phase-1 spec: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/spec.md`
+- Pipeline prompt: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/prompt.md`
+
+# Problem recap
+
+The approved spec requires Secure Custom Fields to replace exact `[[field_name]]` tokens inside Gutenberg-authored post content at render time, without mutating stored `post_content`. v1 is intentionally narrow:
+
+- frontend only
+- singular current-post rendering only
+- only through the standard `the_content` path
+- only for Gutenberg Paragraph and Heading blocks
+- only for an explicit allowlist of scalar/text-capable post field types
+- silent failure for missing, empty, malformed, unsupported, or non-public fields
+- sanitization that preserves only inline-safe HTML
+
+The design therefore needs to solve two tensions at once:
+
+1. be precise enough to touch only the intended Gutenberg render path
+2. reuse existing SCF field loading/formatting behavior without exposing unsupported field values or unsafe HTML
+
+# Goals and non-goals
+
+## Goals
+
+1. Replace exact `[[field_name]]` tokens during frontend render for `core/paragraph` and `core/heading` blocks only.
+2. Leave saved `post_content` unchanged in the database.
+3. Resolve values only from the current post using existing SCF field APIs.
+4. Restrict replacement to an explicit field-type allowlist plus a public-display check.
+5. Sanitize resolved output to an inline-safe HTML subset before insertion.
+6. Fail closed to an empty string for unsupported, missing, empty, non-scalar, or non-public fields.
+7. Reuse existing SCF/ACF formatting caches where possible and avoid repeated work within a single render.
+
+## Non-goals
+
+1. No editor-side live substitution.
+2. No placeholder insertion UI, autocomplete, or validation UI.
+3. No support for excerpts, feeds, REST-rendered content, admin previews, widgets, comments, or non-post objects.
+4. No support for nested placeholders, transforms, filters, or fallback syntax.
+5. No support for structured field outputs such as repeater, group, gallery, relationship, image, file, or arbitrary arrays/objects.
+6. No content migration or stored-content rewrite.
+
+# Architecture overview
+
+## Proposed implementation shape
+
+Add a dedicated frontend service, for example:
+
+- `includes/class-scf-post-content-placeholders.php`
+
+Load it from `secure-custom-fields.php` alongside other frontend/core includes, then instantiate it during plugin bootstrap.
+
+## Service responsibilities
+
+The service should:
+
+1. register the render hook
+2. gate execution to the approved v1 context
+3. scan supported block HTML for exact placeholders
+4. resolve placeholder values from SCF field metadata/value APIs
+5. sanitize resolved values for inline insertion
+6. cache per-request resolved values per post/field
+7. expose narrowly-scoped internal filters for future extension
+
+## Why a dedicated service
+
+A dedicated class keeps the feature isolated from:
+
+- template API behavior (`get_field()`, shortcode)
+- block bindings behavior
+- field-type classes
+- generic `the_content` behavior for non-block content
+
+That isolation matters because the spec is narrower than existing SCF display surfaces.
+
+# Rendering/data flow
+
+## Hook choice
+
+Use block render filtering, not raw whole-content string replacement.
+
+Preferred approach:
+
+- hook `render_block`
+- early-return unless the block is `core/paragraph` or `core/heading`
+
+Rationale:
+
+1. It scopes replacement to the exact Gutenberg block types required by the spec.
+2. It avoids accidentally replacing tokens inside unsupported blocks that also pass through `the_content`.
+3. It still runs during frontend `the_content` rendering because block output is produced by `do_blocks()` inside the normal content pipeline.
+4. It preserves saved block serialization because replacement happens after parsing and during render.
+
+A `the_content`-only implementation would be simpler but too broad for v1 because it could replace tokens in unsupported block output or non-block markup.
+
+## Context gate
+
+The callback should return the original `$block_content` unless all of the following are true:
+
+1. `! is_admin()`
+2. `is_singular()`
+3. `doing_filter( 'the_content' )`
+4. `in_the_loop()`
+5. `is_main_query()`
+6. current block name is exactly `core/paragraph` or `core/heading`
+7. current post ID resolves to a valid post object
+8. block content contains `[[`
+
+This gate intentionally keeps unsupported contexts raw:
+
+- excerpts
+- REST responses
+- feeds
+- editor canvas previews
+- arbitrary `render_block()` consumers outside the singular content loop
+
+## Replacement flow
+
+Per supported block render:
+
+1. Receive rendered block HTML from `render_block`.
+2. Skip immediately if no `[[` substring exists.
+3. Run a regex match for exact placeholders only:
+   - `~\[\[([A-Za-z0-9_-]+)\]\]~`
+4. For each unique placeholder name in the block, resolve a replacement string.
+5. Replace exact matched tokens with the resolved value.
+6. Return the modified block HTML.
+
+## Why exact-regex replacement is sufficient
+
+The regex only matches the approved token shape. Everything else remains untouched by construction:
+
+- `[[movie title]]` does not match
+- `[movie_title]` does not match
+- `[[movie_title]` does not match
+- `[[movie_title|upper]]` does not match
+
+Malformed tokens therefore stay visible to authors, matching the spec.
+
+# Integration points and hooks/APIs
+
+## WordPress integration points
+
+### `render_block`
+
+Primary integration point for replacement.
+
+Expected callback responsibilities:
+
+- inspect block name
+- verify frontend singular `the_content` context
+- rewrite only the rendered HTML string for supported blocks
+
+## SCF/ACF APIs to reuse
+
+### `get_field_object( $selector, $post_id, true, true, false )`
+
+Use strict field lookup by field name against the current post.
+
+Why this API:
+
+- it resolves the actual field object, not just a raw value
+- it provides field type metadata for allowlist checks
+- it uses the field-reference lookup path via `acf_maybe_get_field()`
+- it returns `false` when the field reference is not valid for the current post
+
+This is safer than loose field-name lookups because it stays bound to the current post’s field reference metadata.
+
+### `acf_format_value()` via `get_field_object()`
+
+Let SCF field types perform their existing formatting first. This is especially important for:
+
+- date/time fields
+- select/radio/button-group labels
+- WYSIWYG field content
+
+### `acf_field_type_supports()`
+
+Use as a secondary capability check where helpful, but do not let it replace the explicit v1 allowlist. The spec requires a fixed supported-type contract.
+
+### `acf/prevent_access_to_unknown_fields`
+
+Within placeholder resolution, temporarily enable the same protection pattern already used by the shortcode path so unknown-field access fails closed.
+
+That means:
+
+1. add `__return_true` to `acf/prevent_access_to_unknown_fields` before field lookup if it is not already enabled
+2. remove it after lookups are complete
+
+This prevents loose fallback behavior from loading ad hoc meta when a proper SCF field reference is missing.
+
+## New internal hooks
+
+The feature can add internal/public-but-advanced filters without changing defaults. Suggested names:
+
+- `scf/post_content_placeholders/supported_field_types`
+- `scf/post_content_placeholders/inline_allowed_html`
+- `scf/post_content_placeholders/is_field_allowed`
+- `scf/post_content_placeholders/prepared_value`
+
+These should default to the spec behavior and exist only for future extensibility.
+
+# Data model and state assumptions
+
+## Placeholder token model
+
+A placeholder token is not stored as structured data. It remains literal text inside `post_content` and block attributes/content exactly as authored.
+
+v1 token model:
+
+- opener: `[[`
+- identifier: `[A-Za-z0-9_-]+`
+- closer: `]]`
+
+No nesting, escaping syntax, fallback syntax, or directives are supported.
+
+## Current-post assumption
+
+All lookups are against the currently rendered singular post. No cross-object IDs are parsed from the placeholder.
+
+## Field eligibility state
+
+A placeholder resolves only if all of the following are true:
+
+1. the field exists on the current post via SCF field reference metadata
+2. the field type is in the explicit allowlist
+3. the field is considered public-display-safe for this feature
+4. the formatted value is scalar
+5. the scalar value is not empty after normalization
+
+## Supported field-type allowlist
+
+The design should hardcode the spec’s v1 allowlist, then optionally pass it through a filter:
+
+- `text`
+- `textarea`
+- `number`
+- `range`
+- `email`
+- `url`
+- `select`
+- `radio`
+- `button_group`
+- `date_picker`
+- `date_time_picker`
+- `time_picker`
+- `wysiwyg`
+
+## Additional per-type constraints
+
+### `select`
+
+Only allow a single scalar resolved value.
+
+Reject and return empty when:
+
+- the field is configured for multiple values
+- the formatted value is an array
+- the formatted value is an object or non-scalar
+
+### `wysiwyg`
+
+Allow string output only, then re-sanitize to the placeholder-specific inline HTML subset.
+
+### all other allowed types
+
+Require final formatted output to be scalar.
+
+# Security and sanitization considerations
+
+## Security posture
+
+The implementation should fail closed.
+
+Unsupported or uncertain cases must resolve to `''`, not to raw field data.
+
+## Public-display check for sensitive/non-public fields
+
+The spec excludes fields intended to be non-public. v1 needs an enforceable, code-level rule for that.
+
+Recommended rule:
+
+1. require the field type to be in the explicit allowlist
+2. treat `allow_in_bindings === false` as an explicit deny signal
+3. allow an internal filter (`scf/post_content_placeholders/is_field_allowed`) to deny additional fields
+
+This reuses the repository’s existing field-level exposure concept without adding a new v1 UI.
+
+Behavior detail:
+
+- if a field explicitly disables "Allow Access to Value in Editor UI" (`allow_in_bindings` false), placeholder output is empty
+- if the setting is absent on legacy fields, default behavior follows the saved field object plus the feature’s allowlist/filter checks
+
+This is not a perfect semantic model of "sensitive," but it is the most incremental, testable security boundary already present in the SCF codebase.
+
+## Sanitization pipeline
+
+Do **not** rely solely on `get_field_object(..., true, true, true)` for final insertion, because the built-in escaped HTML path uses the broad `acf` KSES context and may still allow block-level tags such as `<p>` or lists. The spec requires an inline-only subset.
+
+Recommended pipeline:
+
+1. Resolve the formatted value unescaped:
+   - `get_field_object( $name, $post_id, true, true, false )`
+2. Ensure the resulting value is scalar.
+3. Cast to string.
+4. Sanitize using a placeholder-specific allowed-tags list with `wp_kses()`.
+5. Return the sanitized string.
+
+## Inline allowed HTML policy
+
+Create a dedicated allowlist for inline-safe markup only. Suggested baseline:
+
+- `a` with safe URL-related attributes
+- `abbr`
+- `b`
+- `br`
+- `cite`
+- `code`
+- `del`
+- `em`
+- `i`
+- `mark`
+- `small`
+- `span` with a very limited attribute set if needed
+- `strong`
+- `sub`
+- `sup`
+
+Notably excluded:
+
+- `p`
+- headings
+- lists and list items
+- tables
+- div/section/layout wrappers
+- iframe/embed/form/script/style
+- media wrappers
+
+`wp_kses()` will strip disallowed tags while preserving allowed child text/inline markup where possible. That aligns with the spec requirement to strip block-level markup rather than render it structurally.
+
+## URL and attribute safety
+
+If links are allowed, rely on `wp_kses()` to enforce safe attributes and protocols.
+
+## Failure modes
+
+The following all return `''` silently:
+
+- field not found
+- unsupported field type
+- explicitly denied field
+- non-scalar formatted output
+- empty formatted output
+- malformed field data
+- sanitization reducing output to empty
+
+The following remain literal text because they never match the regex:
+
+- malformed placeholders
+- non-exact bracketed tokens
+
+# Compatibility and backward-compatibility considerations
+
+## Stored content compatibility
+
+No migration is required because `post_content` is never rewritten.
+
+## Plugin deactivation behavior
+
+Because saved content remains raw, deactivating SCF naturally falls back to visible `[[field_name]]` text. No cleanup or rollback is needed.
+
+## Gutenberg compatibility
+
+This design is compatible with Gutenberg because it does not:
+
+- alter saved block serialization
+- rewrite block attributes in the editor
+- inject editor-only markup into saved content
+
+The placeholder remains plain text in Paragraph and Heading blocks, so reopening and resaving content should not trigger block validation errors.
+
+## Interaction with existing SCF output surfaces
+
+The feature should not change behavior of:
+
+- `get_field()`
+- `the_field()`
+- shortcode output
+- REST formatting
+- block bindings
+
+It reuses pieces of those systems but adds an isolated render path.
+
+# Performance considerations
+
+## Scope minimization
+
+Most renders should bail out quickly via:
+
+1. singular/frontend/main-loop checks
+2. block-name checks
+3. `strpos( $block_content, '[[' ) === false`
+
+## Value caching
+
+Use two existing/per-request caching layers:
+
+1. SCF formatted value caching inside `acf_format_value()` / value store
+2. a placeholder-service local cache keyed by `post_id + field_name`
+
+The local cache avoids repeating:
+
+- field-object lookup
+- allowlist checks
+- public-display checks
+- inline `wp_kses()` sanitization
+
+Suggested cache shape:
+
+```php
+array(
+	$post_id => array(
+		'movie_title' => 'Resolved value',
+	),
+)
+```
+
+Cache empty-string results too, so repeated missing/unsupported placeholders are cheap.
+
+## Regex cost
+
+Run regex replacement only on supported blocks containing `[[`. This keeps the feature cost proportional to actual placeholder usage.
+
+# Testing strategy
+
+## PHP tests
+
+Add focused PHPUnit coverage for the new service, likely under:
+
+- `tests/php/includes/test-scf-post-content-placeholders.php`
+
+Recommended cases:
+
+1. exact placeholder replacement for supported field types
+2. multiple placeholders in one block string
+3. repeated placeholder in one render uses cached result
+4. malformed tokens remain unchanged
+5. missing field returns empty string
+6. unsupported field type returns empty string
+7. `select` with array output returns empty string
+8. explicit `allow_in_bindings` false returns empty string
+9. WYSIWYG/HTML value preserves allowed inline tags
+10. block-level tags are stripped from WYSIWYG output
+11. unsafe tags/attributes are stripped
+12. unsupported block names are untouched
+13. non-singular or out-of-loop contexts are untouched
+
+Implementation note: these tests should exercise the service methods directly where possible, and use WordPress filter application where integration behavior matters.
+
+## E2E tests
+
+Add a Playwright scenario covering the author workflow, likely with a dedicated test plugin fixture and a new spec such as:
+
+- `tests/e2e/post-content-placeholders.spec.ts`
+
+Recommended E2E flow:
+
+1. create a field group with supported fields attached to posts
+2. create a post containing placeholders in a Paragraph block and a Heading block
+3. save and publish
+4. verify frontend singular view shows resolved values
+5. reopen the post in Gutenberg and confirm the raw placeholder text still exists in the editor content
+6. verify a malformed token remains raw on the frontend
+7. verify at least one unsupported context stays raw, preferably REST content or excerpt output
+8. deactivate SCF and confirm raw placeholder text appears again
+
+## Why both PHP and E2E are needed
+
+- PHP tests cover parsing, gating, field eligibility, and sanitization deterministically.
+- E2E tests prove Gutenberg authoring/save/reopen behavior and deactivation-safe persistence.
+
+# Rollout or migration notes
+
+## Rollout
+
+This can ship as an always-on narrow v1 feature with no migration.
+
+## Migration
+
+None required.
+
+## Documentation follow-up
+
+Post-implementation docs should explain:
+
+- exact placeholder syntax
+- supported blocks
+- supported field types
+- frontend-only limitations
+- empty-output behavior for missing/unsupported fields
+- deactivation behavior
+- inline-HTML sanitization limitations for WYSIWYG values
+
+# Risks
+
+1. **Context-gating drift**: some themes/plugins may call `the_content` or `render_block` in unusual places, so singular/main-loop checks must be conservative.
+2. **Field-publicity ambiguity**: "sensitive/non-public" is a product concept, not a first-class stored field property. Reusing `allow_in_bindings` is incremental but imperfect.
+3. **Sanitization surprises**: users may expect full WYSIWYG markup, but v1 intentionally strips block-level HTML.
+4. **Third-party filter order**: if other filters mutate bracket text before the callback sees it, replacement will not occur.
+5. **Block render assumptions**: if Gutenberg/core changes paragraph or heading render details, block-level targeting may need adjustment, though the exact block names are stable.
+
+# Open questions
+
+1. Should placeholder eligibility require `allow_in_bindings` to be explicitly true, or only deny when it is explicitly false? The former is more conservative; the latter is more backward-compatible.
+2. Should the callback use generic `render_block` with block-name checks, or dynamic block-specific filters if the target WP baseline guarantees them? Generic `render_block` is simpler and easier to reason about.
+3. Should the feature emit `acf/removed_unsafe_html` or a new silent internal action when sanitization strips markup, or stay entirely silent in v1?
+4. Should the inline allowed-tags list include `span`, and if so, which attributes should survive? The narrower the list, the safer and more predictable the output.
+5. Should the service expose a future opt-in filter for additional supported blocks, or keep block support fully hardcoded until a later spec broadens scope?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-v2.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design-v2.md
@@ -1,0 +1,561 @@
+# Task
+
+Create a technical design for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Spec reference
+
+- Approved phase-1 spec: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/spec.md`
+- Pipeline prompt: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/prompt.md`
+- Prior draft: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v1.md`
+- Review outcome for prior draft: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-review-v1.md`
+
+# Problem recap
+
+The approved spec requires Secure Custom Fields to resolve exact `[[field_name]]` tokens inside Gutenberg-authored post content at render time only. Stored `post_content` must remain unchanged, deactivation must reveal the original raw tokens, and unsupported or unsafe cases must fail silently.
+
+The implementation must stay narrow in v1:
+
+- frontend only
+- singular current-post rendering only
+- standard `the_content` rendering path only
+- Gutenberg `core/paragraph` and `core/heading` only
+- exact `[[field_name]]` syntax only
+- explicit allowlist of supported field types only
+- inline-safe HTML only
+- unsupported contexts left raw
+
+This means the design has to be precise about three boundaries:
+
+1. where placeholder parsing runs in the Gutenberg/server render pipeline
+2. which field values are eligible for output at all
+3. exactly which HTML survives sanitization before inline insertion
+
+# Goals and non-goals
+
+## Goals
+
+1. Replace exact `[[field_name]]` tokens during frontend render for `core/paragraph` and `core/heading` blocks only.
+2. Preserve stored `post_content` exactly as authored.
+3. Resolve values only from the currently rendered post using existing SCF field APIs.
+4. Restrict output to an explicit v1 allowlist of field types and a deterministic public-display rule.
+5. Sanitize resolved output to a fixed inline-only HTML subset before insertion.
+6. Fail closed to an empty string for missing, empty, unsupported, non-scalar, denied, or malformed value states.
+7. Keep behavior incremental and isolated from existing shortcode, REST, block bindings, and template APIs.
+
+## Non-goals
+
+1. No editor-side live substitution in the block editor.
+2. No placeholder inserter UI, autocomplete, or editor validation UI.
+3. No support for excerpts, feeds, REST content fields, widgets, comments, admin previews, or non-post objects.
+4. No support for nested placeholders, fallback syntax, transforms, filters, or formatting directives.
+5. No support for structured or collection outputs such as repeater, group, gallery, relationship, image, file, or arbitrary arrays/objects.
+6. No migration of saved content and no serialization changes to Gutenberg blocks.
+
+# Architecture overview
+
+## Proposed implementation shape
+
+Add a dedicated frontend service class:
+
+- `includes/class-scf-post-content-placeholders.php`
+
+Load the file from `secure-custom-fields.php` during the plugin include/bootstrap sequence, then instantiate the service from the main plugin `init()` method after core APIs and field types are loaded.
+
+Concrete bootstrap plan:
+
+1. In `secure-custom-fields.php`, add:
+   - `acf_include( 'includes/class-scf-post-content-placeholders.php' );`
+2. In the main plugin `init()` method, after existing core/frontend includes and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`, instantiate:
+   - `new SCF_Post_Content_Placeholders();`
+3. The class constructor registers exactly one server-side filter:
+   - `add_filter( 'render_block', array( $this, 'filter_render_block' ), 10, 2 );`
+
+Why this lifecycle is correct:
+
+- the class is available only after SCF core APIs such as `get_field_object()`, `acf_field_type_supports()`, and field type registration are loaded
+- hook registration happens during normal plugin initialization, not lazily during a template call
+- the callback exists globally once initialized, but runtime gating inside the callback keeps actual behavior limited to the approved v1 frontend path
+- no editor-side scripts, block serialization hooks, or save-time hooks are introduced
+
+## Service responsibilities
+
+The service is responsible for:
+
+1. registering the block render filter
+2. gating execution to the approved v1 runtime
+3. matching exact placeholder syntax in supported block output
+4. resolving values from the current post via SCF field metadata/value APIs
+5. enforcing the field-type allowlist and public-display rule
+6. sanitizing output to a fixed inline-only allowlist
+7. caching per-request resolution results by post ID and field name
+
+## Why a dedicated service
+
+A dedicated service isolates this feature from:
+
+- shortcode behavior in `includes/api/api-template.php`
+- block bindings behavior in `includes/Blocks/Bindings.php`
+- generic field formatting internals
+- non-block or non-`the_content` rendering paths
+
+That isolation matches the approved spec’s intentionally narrow scope.
+
+# Rendering/data flow
+
+## Hook choice
+
+Use `render_block`, not whole-string replacement on `the_content`.
+
+The service filter runs for all rendered blocks, but only rewrites output when the block name is exactly:
+
+- `core/paragraph`
+- `core/heading`
+
+Rationale:
+
+1. This is narrower than a whole-content `the_content` regex pass.
+2. It precisely matches the spec’s supported Gutenberg block list.
+3. It avoids replacing tokens in unsupported blocks, custom blocks, classic content, excerpts, widgets, or arbitrary HTML that might also pass through `the_content`.
+4. It preserves Gutenberg storage because replacement occurs after parsing and during server render only.
+
+## Runtime gate
+
+`filter_render_block( $block_content, $block )` must return the original `$block_content` unless all of the following are true:
+
+1. `! is_admin()`
+2. `! wp_is_json_request()`
+3. `! is_feed()`
+4. `is_singular()`
+5. `doing_filter( 'the_content' )`
+6. `in_the_loop()`
+7. `is_main_query()`
+8. `$block['blockName']` is exactly `core/paragraph` or `core/heading`
+9. `get_the_ID()` resolves to a valid post ID
+10. `strpos( $block_content, '[[' ) !== false`
+
+This gate is the main mechanism that keeps unsupported contexts raw.
+
+## Replacement flow
+
+For each supported block render:
+
+1. Receive the rendered block HTML string.
+2. Bail out if `[[` is absent.
+3. Match placeholders with this exact regex:
+   - `~\[\[([A-Za-z0-9_-]+)\]\]~`
+4. Build a unique list of placeholder names found in the block.
+5. Resolve each unique placeholder name once for the current post.
+6. Replace exact matches with the resolved sanitized string.
+7. Return the modified block HTML.
+
+All non-matching bracketed text remains unchanged by construction.
+
+## Server/client boundary
+
+Placeholder parsing and substitution happen only on the server in PHP during frontend render.
+
+Not in scope for v1:
+
+- RichText live preview while typing
+- block editor canvas substitution
+- save-time transformation
+- block validation-time transformation
+- REST formatting
+
+This preserves Gutenberg save/reopen behavior because raw placeholder text remains in stored content.
+
+# Integration points and hooks/APIs
+
+## WordPress integration point
+
+### `render_block`
+
+Primary integration point.
+
+The callback should inspect:
+
+- block name
+- current query/render context
+- rendered block HTML
+
+and should only rewrite the returned HTML string for supported blocks.
+
+## SCF/ACF APIs to reuse
+
+### `get_field_object( $selector, $post_id, true, true, false )`
+
+Use this as the primary resolution API.
+
+Reasons:
+
+- returns actual field metadata plus formatted value
+- uses field reference lookup tied to the current post
+- provides field type and field settings needed for eligibility checks
+- fails when no valid field reference exists
+
+### `acf/prevent_access_to_unknown_fields`
+
+Use the shortcode-style protection pattern around field lookup.
+
+Resolution flow must:
+
+1. detect whether the filter is already enabled via `apply_filters( 'acf/prevent_access_to_unknown_fields', false )`
+2. if not enabled, temporarily add `__return_true`
+3. perform field lookup/resolution
+4. remove the temporary filter afterward
+
+This prevents unknown field names from degrading into loose meta access.
+
+### `acf_field_type_supports()`
+
+Optional secondary validation helper, but not the source of truth for v1 eligibility. The explicit spec allowlist remains authoritative.
+
+## New hooks/APIs
+
+Any new extension points should use `scf/...` naming and must not change defaults.
+
+Recommended internal/public filters:
+
+- `scf/post_content_placeholders/supported_field_types`
+- `scf/post_content_placeholders/inline_allowed_html`
+- `scf/post_content_placeholders/is_field_allowed`
+- `scf/post_content_placeholders/prepared_value`
+
+These are optional extension points, not required for v1 correctness.
+
+# Data model and state assumptions
+
+## Placeholder token model
+
+A placeholder remains literal text in saved content.
+
+Exact token grammar:
+
+- opening delimiter: `[[`
+- identifier: one or more of `A-Z`, `a-z`, `0-9`, `_`, `-`
+- closing delimiter: `]]`
+
+No nesting, escaping syntax, or directives are recognized.
+
+## Current-post model
+
+All resolution is against the currently rendered singular post only. No cross-object lookup syntax exists in v1.
+
+## Supported field-type allowlist
+
+The v1 allowlist is fixed to:
+
+- `text`
+- `textarea`
+- `number`
+- `range`
+- `email`
+- `url`
+- `select`
+- `radio`
+- `button_group`
+- `date_picker`
+- `date_time_picker`
+- `time_picker`
+- `wysiwyg`
+
+The implementation may pass this list through `scf/post_content_placeholders/supported_field_types`, but the default list above is the design contract.
+
+## Deterministic field-publicity rule
+
+This draft resolves the blocker from review with a final v1 rule:
+
+A field is eligible for placeholder output only when **all** of the following are true:
+
+1. the field exists on the current post via SCF reference metadata
+2. the field type is in the explicit v1 allowlist
+3. `allow_in_bindings` is present on the field object and strictly truthy
+4. the formatted value is scalar
+5. the formatted scalar is non-empty after normalization
+
+If `allow_in_bindings` is absent, the field is treated as **not allowed** and resolves to an empty string.
+
+Why this is the chosen rule:
+
+- it is the most conservative mapping to the approved spec’s exclusion of sensitive/non-public fields
+- it avoids silently exposing legacy fields whose intended display posture is unknown
+- it is deterministic and implementation-ready
+- it uses an existing SCF exposure control instead of inventing a new v1 UI
+
+Backward-compatibility consequence:
+
+- legacy fields without `allow_in_bindings` set will not render through placeholders until explicitly enabled in field settings or via a future migration/product decision
+
+This is acceptable for v1 because the feature is new and opt-in exposure is safer than implicit exposure.
+
+## Additional per-type constraints
+
+### `select`
+
+Allowed only when the formatted result is a single scalar.
+
+Return empty when:
+
+- the formatted value is an array
+- the field is configured in a way that produces non-scalar output
+
+### `radio` and `button_group`
+
+Allowed only when the formatted result is scalar.
+
+### `wysiwyg`
+
+Allowed only when the formatted result is a string. It is then passed through the placeholder-specific inline HTML sanitization step.
+
+### All other allowed types
+
+Allowed only when the final formatted value is scalar.
+
+# Security and sanitization considerations
+
+## Security posture
+
+The feature fails closed.
+
+Anything uncertain, unsupported, missing, denied, or malformed resolves to `''` or remains literal token text, depending on whether the input matched the exact placeholder grammar.
+
+## Field-resolution safety
+
+To resolve `[[field_name]]` safely:
+
+1. enable `acf/prevent_access_to_unknown_fields` temporarily if needed
+2. call `get_field_object( $field_name, $post_id, true, true, false )`
+3. require a real field object
+4. require the field type allowlist check to pass
+5. require `allow_in_bindings` to be explicitly truthy
+6. require the resolved formatted value to be scalar
+
+This keeps placeholder access aligned with an existing field-level exposure toggle and prevents arbitrary meta reads.
+
+## Final sanitization contract
+
+Do not use `get_field_object( ..., true )` escaped-html output as the final placeholder output because the generic `acf` KSES context is broader than the spec’s inline-only requirement.
+
+Instead, the final insertion pipeline is:
+
+1. get the formatted but unescaped field value
+2. reject non-scalars
+3. cast to string
+4. sanitize via `wp_kses( $value, $allowed_html )` with the fixed allowlist below
+5. return the sanitized string
+
+## Fixed inline HTML allowlist
+
+This draft resolves the blocker from review with a final explicit allowlist.
+
+Allowed tags and attributes:
+
+```php
+array(
+	'a'      => array(
+		'href'   => true,
+		'target' => true,
+		'rel'    => true,
+		'title'  => true,
+	),
+	'abbr'   => array(
+		'title' => true,
+	),
+	'b'      => array(),
+	'br'     => array(),
+	'cite'   => array(),
+	'code'   => array(),
+	'del'    => array(),
+	'em'     => array(),
+	'i'      => array(),
+	'mark'   => array(),
+	'small'  => array(),
+	'strong' => array(),
+	'sub'    => array(),
+	'sup'    => array(),
+)
+```
+
+Final decisions:
+
+- `span` is **not allowed** in v1
+- no `class`, `style`, `id`, `data-*`, `onclick`, or other event attributes are allowed on any tag
+- no block-level tags are allowed, including `p`, `div`, headings, lists, tables, block wrappers, forms, iframes, embeds, scripts, and media containers
+
+Why `span` is excluded:
+
+- it mostly preserves styling hooks rather than semantic inline content
+- excluding it keeps the output contract simpler and more predictable
+- it reduces the chance of carrying theme/editor CSS coupling into placeholder output
+
+## Output behavior examples
+
+- plain text field value `Hello` → `Hello`
+- wysiwyg value `<strong>Hello</strong>` → `<strong>Hello</strong>`
+- wysiwyg value `<p>Hello</p>` → `Hello`
+- wysiwyg value `<ul><li>One</li></ul>` → `One`
+- wysiwyg value `<a href="https://example.com" onclick="x()">Link</a>` → `<a href="https://example.com">Link</a>`
+- wysiwyg value `<span class="x">Hello</span>` → `Hello`
+- unsafe/script markup → stripped, leaving only any safe surviving text
+
+## Failure behavior
+
+Return empty string for:
+
+- field not found
+- field found but `allow_in_bindings` missing or false
+- unsupported field type
+- formatted value is array/object/non-scalar
+- formatted scalar is empty
+- sanitization strips everything
+
+Leave literal token text in place for:
+
+- malformed placeholders that do not match the regex
+
+This matches the spec’s distinction between malformed tokens and exact-syntax placeholders that resolve unsuccessfully.
+
+# Compatibility and backward-compatibility considerations
+
+## Stored content compatibility
+
+No saved content changes are made. Raw placeholders remain in `post_content`.
+
+## Deactivation behavior
+
+Deactivating SCF disables runtime replacement and naturally exposes the original raw placeholder text. No migration or cleanup path is required.
+
+## Gutenberg compatibility
+
+Because the feature does not modify block serialization, editor content, or save-time output, posts containing placeholders can be reopened and resaved without block corruption introduced by this feature.
+
+## Backward-compatibility tradeoff for legacy fields
+
+The explicit `allow_in_bindings === true` requirement means some older fields will not render through placeholders until editors enable field exposure.
+
+This is an intentional v1 security tradeoff:
+
+- favors non-exposure over implicit exposure
+- avoids changing the trust boundary of existing fields silently
+- remains compatible with the spec’s narrow, safety-first first release
+
+# Performance considerations
+
+## Cheap bailouts
+
+The callback should exit early on:
+
+1. unsupported runtime context
+2. unsupported block name
+3. missing `[[` substring
+
+## Per-request caching
+
+Maintain a local cache keyed by post ID and field name, including empty-string results:
+
+```php
+array(
+	123 => array(
+		'movie_title' => 'Example',
+		'missing_key' => '',
+	),
+)
+```
+
+This avoids repeated:
+
+- field object lookup
+- `allow_in_bindings` checks
+- allowlist checks
+- sanitization work
+
+## Reuse existing SCF caches
+
+Because resolution uses standard field APIs, SCF’s existing formatted value cache in `acf_format_value()` also helps reduce repeated cost.
+
+# Testing strategy
+
+## PHP tests
+
+Add a focused test class, e.g.:
+
+- `tests/php/includes/test-scf-post-content-placeholders.php`
+
+Required coverage:
+
+1. paragraph placeholder replacement for a supported text field
+2. heading placeholder replacement for a supported number/date-like field
+3. multiple placeholders in one block
+4. repeated placeholder in one block resolves once and returns cached result
+5. malformed token remains unchanged
+6. missing field returns empty string
+7. unsupported field type returns empty string
+8. `allow_in_bindings` missing returns empty string
+9. `allow_in_bindings` false returns empty string
+10. `allow_in_bindings` true allows supported field output
+11. `select` returning array resolves empty
+12. `wysiwyg` keeps allowed inline tags
+13. block-level tags are stripped
+14. `span` and disallowed attributes are stripped
+15. unsupported block names are untouched
+16. non-frontend or non-`the_content` contexts are untouched
+
+## E2E tests
+
+Add a dedicated Playwright scenario, e.g.:
+
+- `tests/e2e/post-content-placeholders.spec.ts`
+
+Suggested flow:
+
+1. create a post field group with at least one supported field having `allow_in_bindings` enabled
+2. create a post with placeholders in Paragraph and Heading blocks
+3. publish and verify frontend replacement
+4. confirm raw placeholder text still exists in the editor after reopening the post
+5. verify malformed tokens remain visible on frontend
+6. verify a field with `allow_in_bindings` disabled renders empty
+7. verify an unsupported context such as excerpt or REST response stays raw
+8. deactivate the plugin and verify raw placeholder text appears again
+
+## Coverage intent
+
+- PHP tests lock down parsing, gating, eligibility, and sanitization.
+- E2E tests prove Gutenberg compatibility, frontend rendering, and deactivation-safe persistence.
+
+# Rollout or migration notes
+
+## Rollout
+
+Ship as an always-on server-render feature with no user-facing migration.
+
+## Migration
+
+None in v1.
+
+## Documentation follow-up
+
+Documentation should explicitly state:
+
+- exact placeholder syntax
+- supported block types
+- requirement that the field be configured for editor/UI exposure (`allow_in_bindings` enabled)
+- frontend-only behavior
+- empty-output behavior for unsupported or denied fields
+- inline HTML limitations for WYSIWYG values
+- deactivation behavior
+
+# Risks
+
+1. **Adoption friction for legacy fields**: requiring explicit `allow_in_bindings` may surprise users who expect all text-like fields to work immediately.
+2. **Context edge cases**: some themes/plugins may invoke block rendering in unusual ways, so the gating checks must remain conservative.
+3. **Sanitization surprises**: users may expect full WYSIWYG markup, but v1 intentionally strips structural HTML.
+4. **Third-party filter ordering**: other filters may alter bracket text before the supported render path sees it, preventing replacement.
+
+# Open questions
+
+Only non-blocking future questions remain:
+
+1. Should a future version add editor affordances such as autocomplete, insertion UI, or author warnings for unresolved placeholders?
+2. Should a future version expand supported render contexts beyond singular frontend `the_content`?
+3. Should a future version add a dedicated placeholder-access setting separate from block bindings, if product requirements diverge?
+4. Should a future version expand the inline allowlist or supported block list after usage feedback?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/design.md
@@ -1,0 +1,561 @@
+# Task
+
+Create a technical design for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Spec reference
+
+- Approved phase-1 spec: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/spec.md`
+- Pipeline prompt: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/prompt.md`
+- Prior draft: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v1.md`
+- Review outcome for prior draft: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-review-v1.md`
+
+# Problem recap
+
+The approved spec requires Secure Custom Fields to resolve exact `[[field_name]]` tokens inside Gutenberg-authored post content at render time only. Stored `post_content` must remain unchanged, deactivation must reveal the original raw tokens, and unsupported or unsafe cases must fail silently.
+
+The implementation must stay narrow in v1:
+
+- frontend only
+- singular current-post rendering only
+- standard `the_content` rendering path only
+- Gutenberg `core/paragraph` and `core/heading` only
+- exact `[[field_name]]` syntax only
+- explicit allowlist of supported field types only
+- inline-safe HTML only
+- unsupported contexts left raw
+
+This means the design has to be precise about three boundaries:
+
+1. where placeholder parsing runs in the Gutenberg/server render pipeline
+2. which field values are eligible for output at all
+3. exactly which HTML survives sanitization before inline insertion
+
+# Goals and non-goals
+
+## Goals
+
+1. Replace exact `[[field_name]]` tokens during frontend render for `core/paragraph` and `core/heading` blocks only.
+2. Preserve stored `post_content` exactly as authored.
+3. Resolve values only from the currently rendered post using existing SCF field APIs.
+4. Restrict output to an explicit v1 allowlist of field types and a deterministic public-display rule.
+5. Sanitize resolved output to a fixed inline-only HTML subset before insertion.
+6. Fail closed to an empty string for missing, empty, unsupported, non-scalar, denied, or malformed value states.
+7. Keep behavior incremental and isolated from existing shortcode, REST, block bindings, and template APIs.
+
+## Non-goals
+
+1. No editor-side live substitution in the block editor.
+2. No placeholder inserter UI, autocomplete, or editor validation UI.
+3. No support for excerpts, feeds, REST content fields, widgets, comments, admin previews, or non-post objects.
+4. No support for nested placeholders, fallback syntax, transforms, filters, or formatting directives.
+5. No support for structured or collection outputs such as repeater, group, gallery, relationship, image, file, or arbitrary arrays/objects.
+6. No migration of saved content and no serialization changes to Gutenberg blocks.
+
+# Architecture overview
+
+## Proposed implementation shape
+
+Add a dedicated frontend service class:
+
+- `includes/class-scf-post-content-placeholders.php`
+
+Load the file from `secure-custom-fields.php` during the plugin include/bootstrap sequence, then instantiate the service from the main plugin `init()` method after core APIs and field types are loaded.
+
+Concrete bootstrap plan:
+
+1. In `secure-custom-fields.php`, add:
+   - `acf_include( 'includes/class-scf-post-content-placeholders.php' );`
+2. In the main plugin `init()` method, after existing core/frontend includes and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`, instantiate:
+   - `new SCF_Post_Content_Placeholders();`
+3. The class constructor registers exactly one server-side filter:
+   - `add_filter( 'render_block', array( $this, 'filter_render_block' ), 10, 2 );`
+
+Why this lifecycle is correct:
+
+- the class is available only after SCF core APIs such as `get_field_object()`, `acf_field_type_supports()`, and field type registration are loaded
+- hook registration happens during normal plugin initialization, not lazily during a template call
+- the callback exists globally once initialized, but runtime gating inside the callback keeps actual behavior limited to the approved v1 frontend path
+- no editor-side scripts, block serialization hooks, or save-time hooks are introduced
+
+## Service responsibilities
+
+The service is responsible for:
+
+1. registering the block render filter
+2. gating execution to the approved v1 runtime
+3. matching exact placeholder syntax in supported block output
+4. resolving values from the current post via SCF field metadata/value APIs
+5. enforcing the field-type allowlist and public-display rule
+6. sanitizing output to a fixed inline-only allowlist
+7. caching per-request resolution results by post ID and field name
+
+## Why a dedicated service
+
+A dedicated service isolates this feature from:
+
+- shortcode behavior in `includes/api/api-template.php`
+- block bindings behavior in `includes/Blocks/Bindings.php`
+- generic field formatting internals
+- non-block or non-`the_content` rendering paths
+
+That isolation matches the approved spec’s intentionally narrow scope.
+
+# Rendering/data flow
+
+## Hook choice
+
+Use `render_block`, not whole-string replacement on `the_content`.
+
+The service filter runs for all rendered blocks, but only rewrites output when the block name is exactly:
+
+- `core/paragraph`
+- `core/heading`
+
+Rationale:
+
+1. This is narrower than a whole-content `the_content` regex pass.
+2. It precisely matches the spec’s supported Gutenberg block list.
+3. It avoids replacing tokens in unsupported blocks, custom blocks, classic content, excerpts, widgets, or arbitrary HTML that might also pass through `the_content`.
+4. It preserves Gutenberg storage because replacement occurs after parsing and during server render only.
+
+## Runtime gate
+
+`filter_render_block( $block_content, $block )` must return the original `$block_content` unless all of the following are true:
+
+1. `! is_admin()`
+2. `! wp_is_json_request()`
+3. `! is_feed()`
+4. `is_singular()`
+5. `doing_filter( 'the_content' )`
+6. `in_the_loop()`
+7. `is_main_query()`
+8. `$block['blockName']` is exactly `core/paragraph` or `core/heading`
+9. `get_the_ID()` resolves to a valid post ID
+10. `strpos( $block_content, '[[' ) !== false`
+
+This gate is the main mechanism that keeps unsupported contexts raw.
+
+## Replacement flow
+
+For each supported block render:
+
+1. Receive the rendered block HTML string.
+2. Bail out if `[[` is absent.
+3. Match placeholders with this exact regex:
+   - `~\[\[([A-Za-z0-9_-]+)\]\]~`
+4. Build a unique list of placeholder names found in the block.
+5. Resolve each unique placeholder name once for the current post.
+6. Replace exact matches with the resolved sanitized string.
+7. Return the modified block HTML.
+
+All non-matching bracketed text remains unchanged by construction.
+
+## Server/client boundary
+
+Placeholder parsing and substitution happen only on the server in PHP during frontend render.
+
+Not in scope for v1:
+
+- RichText live preview while typing
+- block editor canvas substitution
+- save-time transformation
+- block validation-time transformation
+- REST formatting
+
+This preserves Gutenberg save/reopen behavior because raw placeholder text remains in stored content.
+
+# Integration points and hooks/APIs
+
+## WordPress integration point
+
+### `render_block`
+
+Primary integration point.
+
+The callback should inspect:
+
+- block name
+- current query/render context
+- rendered block HTML
+
+and should only rewrite the returned HTML string for supported blocks.
+
+## SCF/ACF APIs to reuse
+
+### `get_field_object( $selector, $post_id, true, true, false )`
+
+Use this as the primary resolution API.
+
+Reasons:
+
+- returns actual field metadata plus formatted value
+- uses field reference lookup tied to the current post
+- provides field type and field settings needed for eligibility checks
+- fails when no valid field reference exists
+
+### `acf/prevent_access_to_unknown_fields`
+
+Use the shortcode-style protection pattern around field lookup.
+
+Resolution flow must:
+
+1. detect whether the filter is already enabled via `apply_filters( 'acf/prevent_access_to_unknown_fields', false )`
+2. if not enabled, temporarily add `__return_true`
+3. perform field lookup/resolution
+4. remove the temporary filter afterward
+
+This prevents unknown field names from degrading into loose meta access.
+
+### `acf_field_type_supports()`
+
+Optional secondary validation helper, but not the source of truth for v1 eligibility. The explicit spec allowlist remains authoritative.
+
+## New hooks/APIs
+
+Any new extension points should use `scf/...` naming and must not change defaults.
+
+Recommended internal/public filters:
+
+- `scf/post_content_placeholders/supported_field_types`
+- `scf/post_content_placeholders/inline_allowed_html`
+- `scf/post_content_placeholders/is_field_allowed`
+- `scf/post_content_placeholders/prepared_value`
+
+These are optional extension points, not required for v1 correctness.
+
+# Data model and state assumptions
+
+## Placeholder token model
+
+A placeholder remains literal text in saved content.
+
+Exact token grammar:
+
+- opening delimiter: `[[`
+- identifier: one or more of `A-Z`, `a-z`, `0-9`, `_`, `-`
+- closing delimiter: `]]`
+
+No nesting, escaping syntax, or directives are recognized.
+
+## Current-post model
+
+All resolution is against the currently rendered singular post only. No cross-object lookup syntax exists in v1.
+
+## Supported field-type allowlist
+
+The v1 allowlist is fixed to:
+
+- `text`
+- `textarea`
+- `number`
+- `range`
+- `email`
+- `url`
+- `select`
+- `radio`
+- `button_group`
+- `date_picker`
+- `date_time_picker`
+- `time_picker`
+- `wysiwyg`
+
+The implementation may pass this list through `scf/post_content_placeholders/supported_field_types`, but the default list above is the design contract.
+
+## Deterministic field-publicity rule
+
+This draft resolves the blocker from review with a final v1 rule:
+
+A field is eligible for placeholder output only when **all** of the following are true:
+
+1. the field exists on the current post via SCF reference metadata
+2. the field type is in the explicit v1 allowlist
+3. `allow_in_bindings` is present on the field object and strictly truthy
+4. the formatted value is scalar
+5. the formatted scalar is non-empty after normalization
+
+If `allow_in_bindings` is absent, the field is treated as **not allowed** and resolves to an empty string.
+
+Why this is the chosen rule:
+
+- it is the most conservative mapping to the approved spec’s exclusion of sensitive/non-public fields
+- it avoids silently exposing legacy fields whose intended display posture is unknown
+- it is deterministic and implementation-ready
+- it uses an existing SCF exposure control instead of inventing a new v1 UI
+
+Backward-compatibility consequence:
+
+- legacy fields without `allow_in_bindings` set will not render through placeholders until explicitly enabled in field settings or via a future migration/product decision
+
+This is acceptable for v1 because the feature is new and opt-in exposure is safer than implicit exposure.
+
+## Additional per-type constraints
+
+### `select`
+
+Allowed only when the formatted result is a single scalar.
+
+Return empty when:
+
+- the formatted value is an array
+- the field is configured in a way that produces non-scalar output
+
+### `radio` and `button_group`
+
+Allowed only when the formatted result is scalar.
+
+### `wysiwyg`
+
+Allowed only when the formatted result is a string. It is then passed through the placeholder-specific inline HTML sanitization step.
+
+### All other allowed types
+
+Allowed only when the final formatted value is scalar.
+
+# Security and sanitization considerations
+
+## Security posture
+
+The feature fails closed.
+
+Anything uncertain, unsupported, missing, denied, or malformed resolves to `''` or remains literal token text, depending on whether the input matched the exact placeholder grammar.
+
+## Field-resolution safety
+
+To resolve `[[field_name]]` safely:
+
+1. enable `acf/prevent_access_to_unknown_fields` temporarily if needed
+2. call `get_field_object( $field_name, $post_id, true, true, false )`
+3. require a real field object
+4. require the field type allowlist check to pass
+5. require `allow_in_bindings` to be explicitly truthy
+6. require the resolved formatted value to be scalar
+
+This keeps placeholder access aligned with an existing field-level exposure toggle and prevents arbitrary meta reads.
+
+## Final sanitization contract
+
+Do not use `get_field_object( ..., true )` escaped-html output as the final placeholder output because the generic `acf` KSES context is broader than the spec’s inline-only requirement.
+
+Instead, the final insertion pipeline is:
+
+1. get the formatted but unescaped field value
+2. reject non-scalars
+3. cast to string
+4. sanitize via `wp_kses( $value, $allowed_html )` with the fixed allowlist below
+5. return the sanitized string
+
+## Fixed inline HTML allowlist
+
+This draft resolves the blocker from review with a final explicit allowlist.
+
+Allowed tags and attributes:
+
+```php
+array(
+	'a'      => array(
+		'href'   => true,
+		'target' => true,
+		'rel'    => true,
+		'title'  => true,
+	),
+	'abbr'   => array(
+		'title' => true,
+	),
+	'b'      => array(),
+	'br'     => array(),
+	'cite'   => array(),
+	'code'   => array(),
+	'del'    => array(),
+	'em'     => array(),
+	'i'      => array(),
+	'mark'   => array(),
+	'small'  => array(),
+	'strong' => array(),
+	'sub'    => array(),
+	'sup'    => array(),
+)
+```
+
+Final decisions:
+
+- `span` is **not allowed** in v1
+- no `class`, `style`, `id`, `data-*`, `onclick`, or other event attributes are allowed on any tag
+- no block-level tags are allowed, including `p`, `div`, headings, lists, tables, block wrappers, forms, iframes, embeds, scripts, and media containers
+
+Why `span` is excluded:
+
+- it mostly preserves styling hooks rather than semantic inline content
+- excluding it keeps the output contract simpler and more predictable
+- it reduces the chance of carrying theme/editor CSS coupling into placeholder output
+
+## Output behavior examples
+
+- plain text field value `Hello` → `Hello`
+- wysiwyg value `<strong>Hello</strong>` → `<strong>Hello</strong>`
+- wysiwyg value `<p>Hello</p>` → `Hello`
+- wysiwyg value `<ul><li>One</li></ul>` → `One`
+- wysiwyg value `<a href="https://example.com" onclick="x()">Link</a>` → `<a href="https://example.com">Link</a>`
+- wysiwyg value `<span class="x">Hello</span>` → `Hello`
+- unsafe/script markup → stripped, leaving only any safe surviving text
+
+## Failure behavior
+
+Return empty string for:
+
+- field not found
+- field found but `allow_in_bindings` missing or false
+- unsupported field type
+- formatted value is array/object/non-scalar
+- formatted scalar is empty
+- sanitization strips everything
+
+Leave literal token text in place for:
+
+- malformed placeholders that do not match the regex
+
+This matches the spec’s distinction between malformed tokens and exact-syntax placeholders that resolve unsuccessfully.
+
+# Compatibility and backward-compatibility considerations
+
+## Stored content compatibility
+
+No saved content changes are made. Raw placeholders remain in `post_content`.
+
+## Deactivation behavior
+
+Deactivating SCF disables runtime replacement and naturally exposes the original raw placeholder text. No migration or cleanup path is required.
+
+## Gutenberg compatibility
+
+Because the feature does not modify block serialization, editor content, or save-time output, posts containing placeholders can be reopened and resaved without block corruption introduced by this feature.
+
+## Backward-compatibility tradeoff for legacy fields
+
+The explicit `allow_in_bindings === true` requirement means some older fields will not render through placeholders until editors enable field exposure.
+
+This is an intentional v1 security tradeoff:
+
+- favors non-exposure over implicit exposure
+- avoids changing the trust boundary of existing fields silently
+- remains compatible with the spec’s narrow, safety-first first release
+
+# Performance considerations
+
+## Cheap bailouts
+
+The callback should exit early on:
+
+1. unsupported runtime context
+2. unsupported block name
+3. missing `[[` substring
+
+## Per-request caching
+
+Maintain a local cache keyed by post ID and field name, including empty-string results:
+
+```php
+array(
+	123 => array(
+		'movie_title' => 'Example',
+		'missing_key' => '',
+	),
+)
+```
+
+This avoids repeated:
+
+- field object lookup
+- `allow_in_bindings` checks
+- allowlist checks
+- sanitization work
+
+## Reuse existing SCF caches
+
+Because resolution uses standard field APIs, SCF’s existing formatted value cache in `acf_format_value()` also helps reduce repeated cost.
+
+# Testing strategy
+
+## PHP tests
+
+Add a focused test class, e.g.:
+
+- `tests/php/includes/test-scf-post-content-placeholders.php`
+
+Required coverage:
+
+1. paragraph placeholder replacement for a supported text field
+2. heading placeholder replacement for a supported number/date-like field
+3. multiple placeholders in one block
+4. repeated placeholder in one block resolves once and returns cached result
+5. malformed token remains unchanged
+6. missing field returns empty string
+7. unsupported field type returns empty string
+8. `allow_in_bindings` missing returns empty string
+9. `allow_in_bindings` false returns empty string
+10. `allow_in_bindings` true allows supported field output
+11. `select` returning array resolves empty
+12. `wysiwyg` keeps allowed inline tags
+13. block-level tags are stripped
+14. `span` and disallowed attributes are stripped
+15. unsupported block names are untouched
+16. non-frontend or non-`the_content` contexts are untouched
+
+## E2E tests
+
+Add a dedicated Playwright scenario, e.g.:
+
+- `tests/e2e/post-content-placeholders.spec.ts`
+
+Suggested flow:
+
+1. create a post field group with at least one supported field having `allow_in_bindings` enabled
+2. create a post with placeholders in Paragraph and Heading blocks
+3. publish and verify frontend replacement
+4. confirm raw placeholder text still exists in the editor after reopening the post
+5. verify malformed tokens remain visible on frontend
+6. verify a field with `allow_in_bindings` disabled renders empty
+7. verify an unsupported context such as excerpt or REST response stays raw
+8. deactivate the plugin and verify raw placeholder text appears again
+
+## Coverage intent
+
+- PHP tests lock down parsing, gating, eligibility, and sanitization.
+- E2E tests prove Gutenberg compatibility, frontend rendering, and deactivation-safe persistence.
+
+# Rollout or migration notes
+
+## Rollout
+
+Ship as an always-on server-render feature with no user-facing migration.
+
+## Migration
+
+None in v1.
+
+## Documentation follow-up
+
+Documentation should explicitly state:
+
+- exact placeholder syntax
+- supported block types
+- requirement that the field be configured for editor/UI exposure (`allow_in_bindings` enabled)
+- frontend-only behavior
+- empty-output behavior for unsupported or denied fields
+- inline HTML limitations for WYSIWYG values
+- deactivation behavior
+
+# Risks
+
+1. **Adoption friction for legacy fields**: requiring explicit `allow_in_bindings` may surprise users who expect all text-like fields to work immediately.
+2. **Context edge cases**: some themes/plugins may invoke block rendering in unusual ways, so the gating checks must remain conservative.
+3. **Sanitization surprises**: users may expect full WYSIWYG markup, but v1 intentionally strips structural HTML.
+4. **Third-party filter ordering**: other filters may alter bracket text before the supported render path sees it, preventing replacement.
+
+# Open questions
+
+Only non-blocking future questions remain:
+
+1. Should a future version add editor affordances such as autocomplete, insertion UI, or author warnings for unresolved placeholders?
+2. Should a future version expand supported render contexts beyond singular frontend `the_content`?
+3. Should a future version add a dedicated placeholder-access setting separate from block bindings, if product requirements diverge?
+4. Should a future version expand the inline allowlist or supported block list after usage feedback?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan-review-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan-review-v1.md
@@ -1,0 +1,34 @@
+Decision: APPROVE
+
+Why
+- The plan is traceable to the approved spec and approved design, and it stays within the narrow v1 scope.
+- It identifies the correct implementation surface:
+  - new dedicated service class in `includes/class-scf-post-content-placeholders.php`
+  - bootstrap include in `secure-custom-fields.php`
+  - runtime registration through a single `render_block` filter
+- The runtime gating, placeholder parsing, field-resolution rules, `allow_in_bindings` enforcement, inline-only sanitization, and cache behavior all map cleanly back to the approved design.
+- File targets and bootstrap points are correct for this repository. The plan places inclusion in the main bootstrap include list and instantiation inside `ACF::init()` before `do_action( 'acf/init', ACF_MAJOR_VERSION );`, which is consistent with the approved design and existing plugin lifecycle.
+- The plan covers the key safety requirements explicitly:
+  - exact-regex matching only
+  - no save-time mutation
+  - no broad `the_content` whole-string replacement
+  - no unsupported contexts
+  - no structured/non-scalar output
+  - no unsafe HTML execution
+- Test coverage is sufficiently complete across PHP and E2E for the approved v1 behavior, including malformed tokens, unsupported blocks/contexts, `allow_in_bindings`, sanitization, persistence, and deactivation behavior.
+- The sequencing is safe: bootstrap first, then runtime gating/parsing/resolution/sanitization, then tests and validation.
+
+Plan notes
+- The plan correctly keeps replacement limited to `core/paragraph` and `core/heading` block output via `render_block`, rather than broadening scope to classic content or arbitrary `the_content` HTML.
+- The bootstrap details are concrete enough to implement without guesswork and align with the actual `secure-custom-fields.php` initialization flow.
+- The safe field-resolution tasks are implementation-ready and correctly reuse the repository’s existing unknown-field access protection pattern from shortcode-related logic.
+- The sanitization section is explicit and consistent with the approved inline-only allowlist from the design.
+- The proposed PHP test file path `tests/php/includes/test-scf-post-content-placeholders.php` and E2E spec path `tests/e2e/post-content-placeholders.spec.ts` fit existing repository conventions.
+- Optional helper changes are clearly marked as optional and do not expand scope.
+
+Required changes
+- None.
+
+Next version expected
+- No implementation-plan v2 required.
+- Proceed to implementation using `implementation-plan-v1.md`.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan-v1.md
@@ -1,0 +1,374 @@
+# Task
+
+Create an implementation-ready phase-3 plan for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Spec reference
+
+- Approved spec: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/spec.md`
+- Approved design: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design.md`
+- Approved design review: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-review-v2.md`
+
+# Design reference
+
+- Primary design document: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design.md`
+- Prior rejected draft for context: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v1.md`
+- Current approved design revision: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v2.md`
+
+# Implementation summary
+
+Implement a new frontend-only placeholder service that hooks into `render_block`, rewrites only rendered `core/paragraph` and `core/heading` block HTML during supported singular `the_content` renders, resolves exact `[[field_name]]` tokens against the current post via SCF field APIs, enforces the approved v1 field allowlist plus explicit `allow_in_bindings` opt-in, sanitizes values to a fixed inline-only HTML subset, and leaves unsupported or malformed cases raw or empty according to the approved spec.
+
+The implementation should stay tightly scoped to the approved v1 behavior:
+
+- no save-time mutation of `post_content`
+- no editor-side live substitution
+- no REST/excerpt/feed support
+- no support beyond paragraph and heading blocks
+- no structured/non-scalar field output
+- no broad `the_content` whole-string replacement
+
+# Work breakdown
+
+1. **Add the placeholder service class**
+   - Create `includes/class-scf-post-content-placeholders.php`.
+   - Implement constructor-based hook registration for `render_block`.
+   - Add private/protected helpers for runtime gating, placeholder extraction, field resolution, allowlist checks, inline sanitization, and per-request caching.
+
+2. **Bootstrap the service in plugin load/init flow**
+   - Include the new class file from `secure-custom-fields.php` during plugin bootstrap.
+   - Instantiate the service inside `ACF::init()` after field types are loaded and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`.
+   - Keep instantiation unconditional, with runtime checks inside the service preventing unsupported execution.
+
+3. **Implement supported runtime gating**
+   - In the `render_block` callback, bail unless all approved conditions are met:
+     - frontend only
+     - non-JSON request
+     - non-feed
+     - singular request
+     - inside `the_content`
+     - main query / loop
+     - block name exactly `core/paragraph` or `core/heading`
+     - valid current post ID
+     - block output contains `[[`
+   - Return original block HTML untouched for all unsupported contexts.
+
+4. **Implement exact placeholder parsing and replacement**
+   - Match only `[[field_name]]` via the approved regex `~\[\[([A-Za-z0-9_-]+)\]\]~`.
+   - Deduplicate placeholder names per block before lookup.
+   - Replace exact matches only; malformed or non-exact bracketed text must remain untouched.
+   - Ensure multiple and repeated placeholders in one block are supported deterministically.
+
+5. **Implement safe field resolution**
+   - Resolve values with `get_field_object( $field_name, $post_id, true, true, false )`.
+   - Follow the approved temporary unknown-field protection pattern around `acf/prevent_access_to_unknown_fields`.
+   - Require a real field object tied to the current post.
+   - Reject unsupported field types, absent/false `allow_in_bindings`, non-scalar values, and empty normalized values.
+   - Cache results per request by post ID + field name, including empty-string failures.
+
+6. **Implement inline-only sanitization**
+   - Add a fixed placeholder-specific allowed HTML map using the approved tags/attributes only.
+   - Sanitize final string output with `wp_kses()`.
+   - Preserve safe inline HTML for supported values.
+   - Strip block-level and disallowed markup rather than rendering it.
+   - Return empty string if sanitization yields no usable output.
+
+7. **Add PHP automated coverage**
+   - Create a focused PHPUnit test file for the new service.
+   - Cover runtime gating, replacement behavior, unsupported field behavior, `allow_in_bindings` behavior, scalar checks, sanitization, and malformed token handling.
+
+8. **Add E2E coverage for Gutenberg authoring and frontend rendering**
+   - Add a new Playwright spec focused on paragraph/heading placeholders.
+   - Verify authoring, save/reopen behavior, frontend replacement, unsupported token behavior, raw persistence, and deactivation-safe behavior.
+
+9. **Run targeted validation**
+   - Execute targeted PHPUnit tests for the new class.
+   - Execute the focused E2E scenario through repository npm scripts.
+   - Optionally run relevant lint/format commands if the implementation introduces style issues.
+
+# File-by-file changes
+
+## `secure-custom-fields.php`
+
+Planned changes:
+
+- Add `acf_include( 'includes/class-scf-post-content-placeholders.php' );` in the main bootstrap include list.
+- Instantiate `new SCF_Post_Content_Placeholders();` in `ACF::init()` after field types are available and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`.
+
+Why:
+
+- The service must be loaded early enough to be available in runtime, but instantiated only after SCF field APIs and field-type registrations exist.
+
+## `includes/class-scf-post-content-placeholders.php` (new)
+
+Planned contents:
+
+- New `SCF_Post_Content_Placeholders` class.
+- Constructor registering `add_filter( 'render_block', array( $this, 'filter_render_block' ), 10, 2 );`.
+- Methods/helpers for:
+  - supported runtime checks
+  - supported block-name checks
+  - placeholder regex matching
+  - unique placeholder extraction
+  - request-local cache reads/writes
+  - temporary `acf/prevent_access_to_unknown_fields` protection
+  - field lookup and eligibility checks
+  - final placeholder-specific inline sanitization
+  - allowed HTML map definition
+- Optional internal filters only if implementation needs them and they do not change defaults:
+  - `scf/post_content_placeholders/supported_field_types`
+  - `scf/post_content_placeholders/inline_allowed_html`
+  - `scf/post_content_placeholders/is_field_allowed`
+  - `scf/post_content_placeholders/prepared_value`
+
+Why:
+
+- Keeps the feature isolated from shortcode, REST, and generic block-binding behavior while matching the approved design.
+
+## `tests/php/includes/test-scf-post-content-placeholders.php` (new)
+
+Planned coverage:
+
+- paragraph replacement success
+- heading replacement success
+- multiple placeholders in one block
+- repeated placeholder reuse/cache behavior at output level
+- malformed token remains unchanged
+- missing field returns empty
+- unsupported field type returns empty
+- `allow_in_bindings` absent returns empty
+- `allow_in_bindings` false returns empty
+- `allow_in_bindings` true permits supported field output
+- non-scalar/select-array result returns empty
+- `wysiwyg` inline HTML preservation
+- block-level/disallowed markup stripping
+- unsupported block name remains untouched
+- unsupported runtime/context remains untouched
+
+Why:
+
+- Most feature risk is in PHP render-time behavior, so coverage should lock down exact parsing, gating, safety, and sanitization contracts.
+
+## `tests/e2e/post-content-placeholders.spec.ts` (new)
+
+Planned coverage:
+
+- create/configure a field group with supported fields
+- ensure placeholder-capable field has `allow_in_bindings` enabled
+- create a post using paragraph and heading placeholders
+- verify frontend replacement after save/publish
+- reopen editor and confirm raw placeholders remain in content
+- verify malformed tokens still render literally
+- verify disabled/denied field resolves empty
+- verify at least one unsupported context stays raw
+- deactivate plugin and verify raw placeholder text reappears
+
+Why:
+
+- Confirms the feature works through Gutenberg save/reopen/frontend flows, not just in isolated PHP tests.
+
+## Possible existing test helpers touched only if needed
+
+### `tests/e2e/field-helpers.js`
+
+Potential changes:
+
+- Only update if a reusable helper is needed to create fields with `allow_in_bindings` enabled or to simplify post-content setup.
+
+### `tests/e2e/fixtures.js`
+
+Potential changes:
+
+- Only update if common admin/editor setup needs a new fixture utility.
+
+These helper changes are optional; prefer keeping the first E2E spec self-contained unless duplication becomes excessive.
+
+# Hook/bootstrap changes
+
+1. **Plugin bootstrap include**
+   - Add the new placeholder class file to the core include list in `secure-custom-fields.php`.
+
+2. **Plugin init instantiation**
+   - Instantiate the service in `ACF::init()` after field-type includes and before `acf/init` fires.
+
+3. **Runtime filter registration**
+   - Register one new filter:
+     - `render_block` → `SCF_Post_Content_Placeholders::filter_render_block()`
+
+4. **No save/editor bootstrap additions**
+   - Do not add hooks for block serialization, `save_post`, editor JS, REST formatting, or broad `the_content` replacement.
+
+5. **Possible internal extension filters**
+   - Only add `scf/...` filters if needed to encapsulate internal policy without widening the default scope.
+
+# Data flow changes
+
+1. WordPress renders a post through the normal frontend singular `the_content` pipeline.
+2. Each Gutenberg block passes through `render_block`.
+3. The new service receives rendered block HTML and the parsed block array.
+4. The service returns early unless the render matches the approved v1 runtime and block constraints.
+5. For supported paragraph/heading block HTML containing `[[`, the service scans for exact placeholders.
+6. The service deduplicates matched field names per block.
+7. For each unique field name, the service:
+   - checks cache for the current post ID
+   - temporarily enables `acf/prevent_access_to_unknown_fields` if not already enabled
+   - calls `get_field_object()` for the current post
+   - validates type allowlist and `allow_in_bindings`
+   - ensures the resolved formatted value is scalar and non-empty
+   - sanitizes the final string through placeholder-specific inline KSES
+   - stores the final string or empty string in cache
+8. The service replaces exact placeholder matches in block HTML with the resolved sanitized strings.
+9. The rendered post continues through the normal output pipeline.
+10. Stored `post_content` remains unchanged throughout.
+
+# Sanitization and security tasks
+
+1. **Unknown-field access hardening**
+   - Reuse the existing shortcode-style `acf/prevent_access_to_unknown_fields` pattern during placeholder resolution.
+   - Ensure temporary filter removal happens reliably after lookup.
+
+2. **Supported type enforcement**
+   - Implement the approved explicit allowlist only:
+     - `text`
+     - `textarea`
+     - `number`
+     - `range`
+     - `email`
+     - `url`
+     - `select` when scalar
+     - `radio`
+     - `button_group`
+     - `date_picker`
+     - `date_time_picker`
+     - `time_picker`
+     - `wysiwyg`
+
+3. **Public-display enforcement**
+   - Require `allow_in_bindings` to be present and truthy.
+   - Treat missing or false values as denied output.
+
+4. **Scalar-only enforcement**
+   - Reject arrays, objects, and other non-scalar outputs.
+   - Treat multi-select/array-like outputs as unsupported for this render.
+
+5. **Inline-only HTML sanitization**
+   - Use a fixed `wp_kses()` allowlist for:
+     - `a[href,target,rel,title]`
+     - `abbr[title]`
+     - `b`, `br`, `cite`, `code`, `del`, `em`, `i`, `mark`, `small`, `strong`, `sub`, `sup`
+   - Explicitly exclude `span`, `class`, `style`, `id`, `data-*`, event attributes, and all block-level tags.
+
+6. **Silent failure behavior**
+   - Exact placeholders with missing/denied/unsupported/empty results must render `''`.
+   - Malformed tokens must remain literal.
+   - No user-facing warnings, comments, or debug strings should be injected.
+
+7. **No unsafe execution paths**
+   - Do not evaluate shortcodes, scripts, embeds, event handlers, or arbitrary HTML as part of placeholder output.
+
+# Test plan
+
+## PHPUnit
+
+Run targeted tests for the new class first, then broader PHP coverage if needed:
+
+```bash
+composer test:php -- --filter Post_Content_Placeholders
+# or
+vendor/bin/phpunit tests/php/includes/test-scf-post-content-placeholders.php
+```
+
+Minimum PHPUnit assertions:
+
+- supported placeholder replacement in paragraph output
+- supported placeholder replacement in heading output
+- repeated placeholders produce same output
+- malformed tokens remain unchanged
+- missing fields resolve empty
+- unsupported block names are untouched
+- unsupported runtime gates are untouched
+- unsupported field types resolve empty
+- missing/false `allow_in_bindings` resolves empty
+- safe inline HTML is preserved
+- block-level/disallowed tags are stripped
+- array/non-scalar values resolve empty
+
+## E2E
+
+Run the focused Playwright spec through the required npm wrapper:
+
+```bash
+npm run test:e2e -- tests/e2e/post-content-placeholders.spec.ts
+```
+
+Minimum E2E assertions:
+
+- placeholder survives save/reopen in Gutenberg
+- frontend paragraph replacement works
+- frontend heading replacement works
+- malformed token remains raw on frontend
+- unsupported/denied field renders empty
+- unsupported context remains raw
+- deactivation reveals original raw placeholder text
+
+## Optional quality checks
+
+If implementation touches multiple files or triggers formatting issues:
+
+```bash
+composer lint:php
+npx wp-scripts lint-js
+```
+
+Only run JS lint if helper/spec changes require it.
+
+# Rollout/verification steps
+
+1. Build the feature behind normal plugin initialization with no migration.
+2. Create a manual verification post with paragraph and heading placeholders.
+3. Confirm frontend singular rendering replaces supported placeholders.
+4. Confirm the editor still shows raw `[[field_name]]` text after reopen/resave.
+5. Confirm excerpts/REST/feed behavior remains raw or otherwise untouched.
+6. Confirm a denied field (`allow_in_bindings` disabled) renders empty without warnings.
+7. Confirm a WYSIWYG field preserves safe inline markup but strips structural HTML.
+8. Deactivate the plugin and confirm raw placeholder text becomes visible again.
+9. If all tests and manual checks pass, the orchestrator can promote the approved plan and proceed to implementation.
+
+# Risks and dependencies
+
+## Risks
+
+1. **Legacy field behavior surprise**
+   - Existing fields may default to `allow_in_bindings` true in some stored contexts, while the design requires explicit presence + truthiness checks for placeholders. Implementation must follow the approved design exactly, and tests should document this behavior.
+
+2. **Context-gating edge cases**
+   - Theme/plugin variations in `render_block`, loop state, or content rendering order may reveal edge cases; the gate should remain conservative rather than trying to broaden support.
+
+3. **Sanitization surprises for WYSIWYG values**
+   - Users may expect full rich markup, but v1 intentionally strips block-level structure.
+
+4. **Test setup complexity**
+   - E2E setup may need careful field creation/configuration to ensure `allow_in_bindings` is enabled and predictable.
+
+## Dependencies
+
+- Existing SCF APIs, especially `get_field_object()` and field type registration in `ACF::init()`.
+- WordPress frontend block render pipeline via `render_block`.
+- Existing field setting `allow_in_bindings` behavior.
+- Existing PHPUnit bootstrap and E2E wp-env setup.
+
+# Out of scope
+
+- Replacing placeholders in excerpts, REST content, feeds, widgets, comments, or admin previews.
+- Supporting blocks beyond `core/paragraph` and `core/heading`.
+- Save-time content mutation or serialization changes.
+- Live editor preview/substitution while typing.
+- Cross-object lookups or field-key syntax.
+- Nested placeholders, fallback syntax, filters, or formatting directives.
+- Structured field rendering for repeaters, groups, images, files, relationships, or arbitrary arrays/objects.
+- User-facing UI for inserting or validating placeholders.
+
+# Open questions
+
+1. During implementation, do existing PHP test utilities already provide a clean pattern for simulating `render_block` in-loop singular contexts, or will the new test class need small custom setup?
+2. For E2E coverage of unsupported contexts, is excerpt rendering the simplest stable assertion, or is a REST response check more reliable in this repository’s test environment?
+3. If minor helper extraction is needed for E2E field setup, should it stay local to the new spec or be promoted into shared helpers after the first implementation lands?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/implementation-plan.md
@@ -1,0 +1,374 @@
+# Task
+
+Create an implementation-ready phase-3 plan for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Spec reference
+
+- Approved spec: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/spec.md`
+- Approved design: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design.md`
+- Approved design review: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-review-v2.md`
+
+# Design reference
+
+- Primary design document: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design.md`
+- Prior rejected draft for context: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v1.md`
+- Current approved design revision: `.pi/pipelines/issue-419-gutenberg-custom-field-placeholders/design-v2.md`
+
+# Implementation summary
+
+Implement a new frontend-only placeholder service that hooks into `render_block`, rewrites only rendered `core/paragraph` and `core/heading` block HTML during supported singular `the_content` renders, resolves exact `[[field_name]]` tokens against the current post via SCF field APIs, enforces the approved v1 field allowlist plus explicit `allow_in_bindings` opt-in, sanitizes values to a fixed inline-only HTML subset, and leaves unsupported or malformed cases raw or empty according to the approved spec.
+
+The implementation should stay tightly scoped to the approved v1 behavior:
+
+- no save-time mutation of `post_content`
+- no editor-side live substitution
+- no REST/excerpt/feed support
+- no support beyond paragraph and heading blocks
+- no structured/non-scalar field output
+- no broad `the_content` whole-string replacement
+
+# Work breakdown
+
+1. **Add the placeholder service class**
+   - Create `includes/class-scf-post-content-placeholders.php`.
+   - Implement constructor-based hook registration for `render_block`.
+   - Add private/protected helpers for runtime gating, placeholder extraction, field resolution, allowlist checks, inline sanitization, and per-request caching.
+
+2. **Bootstrap the service in plugin load/init flow**
+   - Include the new class file from `secure-custom-fields.php` during plugin bootstrap.
+   - Instantiate the service inside `ACF::init()` after field types are loaded and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`.
+   - Keep instantiation unconditional, with runtime checks inside the service preventing unsupported execution.
+
+3. **Implement supported runtime gating**
+   - In the `render_block` callback, bail unless all approved conditions are met:
+     - frontend only
+     - non-JSON request
+     - non-feed
+     - singular request
+     - inside `the_content`
+     - main query / loop
+     - block name exactly `core/paragraph` or `core/heading`
+     - valid current post ID
+     - block output contains `[[`
+   - Return original block HTML untouched for all unsupported contexts.
+
+4. **Implement exact placeholder parsing and replacement**
+   - Match only `[[field_name]]` via the approved regex `~\[\[([A-Za-z0-9_-]+)\]\]~`.
+   - Deduplicate placeholder names per block before lookup.
+   - Replace exact matches only; malformed or non-exact bracketed text must remain untouched.
+   - Ensure multiple and repeated placeholders in one block are supported deterministically.
+
+5. **Implement safe field resolution**
+   - Resolve values with `get_field_object( $field_name, $post_id, true, true, false )`.
+   - Follow the approved temporary unknown-field protection pattern around `acf/prevent_access_to_unknown_fields`.
+   - Require a real field object tied to the current post.
+   - Reject unsupported field types, absent/false `allow_in_bindings`, non-scalar values, and empty normalized values.
+   - Cache results per request by post ID + field name, including empty-string failures.
+
+6. **Implement inline-only sanitization**
+   - Add a fixed placeholder-specific allowed HTML map using the approved tags/attributes only.
+   - Sanitize final string output with `wp_kses()`.
+   - Preserve safe inline HTML for supported values.
+   - Strip block-level and disallowed markup rather than rendering it.
+   - Return empty string if sanitization yields no usable output.
+
+7. **Add PHP automated coverage**
+   - Create a focused PHPUnit test file for the new service.
+   - Cover runtime gating, replacement behavior, unsupported field behavior, `allow_in_bindings` behavior, scalar checks, sanitization, and malformed token handling.
+
+8. **Add E2E coverage for Gutenberg authoring and frontend rendering**
+   - Add a new Playwright spec focused on paragraph/heading placeholders.
+   - Verify authoring, save/reopen behavior, frontend replacement, unsupported token behavior, raw persistence, and deactivation-safe behavior.
+
+9. **Run targeted validation**
+   - Execute targeted PHPUnit tests for the new class.
+   - Execute the focused E2E scenario through repository npm scripts.
+   - Optionally run relevant lint/format commands if the implementation introduces style issues.
+
+# File-by-file changes
+
+## `secure-custom-fields.php`
+
+Planned changes:
+
+- Add `acf_include( 'includes/class-scf-post-content-placeholders.php' );` in the main bootstrap include list.
+- Instantiate `new SCF_Post_Content_Placeholders();` in `ACF::init()` after field types are available and before `do_action( 'acf/init', ACF_MAJOR_VERSION );`.
+
+Why:
+
+- The service must be loaded early enough to be available in runtime, but instantiated only after SCF field APIs and field-type registrations exist.
+
+## `includes/class-scf-post-content-placeholders.php` (new)
+
+Planned contents:
+
+- New `SCF_Post_Content_Placeholders` class.
+- Constructor registering `add_filter( 'render_block', array( $this, 'filter_render_block' ), 10, 2 );`.
+- Methods/helpers for:
+  - supported runtime checks
+  - supported block-name checks
+  - placeholder regex matching
+  - unique placeholder extraction
+  - request-local cache reads/writes
+  - temporary `acf/prevent_access_to_unknown_fields` protection
+  - field lookup and eligibility checks
+  - final placeholder-specific inline sanitization
+  - allowed HTML map definition
+- Optional internal filters only if implementation needs them and they do not change defaults:
+  - `scf/post_content_placeholders/supported_field_types`
+  - `scf/post_content_placeholders/inline_allowed_html`
+  - `scf/post_content_placeholders/is_field_allowed`
+  - `scf/post_content_placeholders/prepared_value`
+
+Why:
+
+- Keeps the feature isolated from shortcode, REST, and generic block-binding behavior while matching the approved design.
+
+## `tests/php/includes/test-scf-post-content-placeholders.php` (new)
+
+Planned coverage:
+
+- paragraph replacement success
+- heading replacement success
+- multiple placeholders in one block
+- repeated placeholder reuse/cache behavior at output level
+- malformed token remains unchanged
+- missing field returns empty
+- unsupported field type returns empty
+- `allow_in_bindings` absent returns empty
+- `allow_in_bindings` false returns empty
+- `allow_in_bindings` true permits supported field output
+- non-scalar/select-array result returns empty
+- `wysiwyg` inline HTML preservation
+- block-level/disallowed markup stripping
+- unsupported block name remains untouched
+- unsupported runtime/context remains untouched
+
+Why:
+
+- Most feature risk is in PHP render-time behavior, so coverage should lock down exact parsing, gating, safety, and sanitization contracts.
+
+## `tests/e2e/post-content-placeholders.spec.ts` (new)
+
+Planned coverage:
+
+- create/configure a field group with supported fields
+- ensure placeholder-capable field has `allow_in_bindings` enabled
+- create a post using paragraph and heading placeholders
+- verify frontend replacement after save/publish
+- reopen editor and confirm raw placeholders remain in content
+- verify malformed tokens still render literally
+- verify disabled/denied field resolves empty
+- verify at least one unsupported context stays raw
+- deactivate plugin and verify raw placeholder text reappears
+
+Why:
+
+- Confirms the feature works through Gutenberg save/reopen/frontend flows, not just in isolated PHP tests.
+
+## Possible existing test helpers touched only if needed
+
+### `tests/e2e/field-helpers.js`
+
+Potential changes:
+
+- Only update if a reusable helper is needed to create fields with `allow_in_bindings` enabled or to simplify post-content setup.
+
+### `tests/e2e/fixtures.js`
+
+Potential changes:
+
+- Only update if common admin/editor setup needs a new fixture utility.
+
+These helper changes are optional; prefer keeping the first E2E spec self-contained unless duplication becomes excessive.
+
+# Hook/bootstrap changes
+
+1. **Plugin bootstrap include**
+   - Add the new placeholder class file to the core include list in `secure-custom-fields.php`.
+
+2. **Plugin init instantiation**
+   - Instantiate the service in `ACF::init()` after field-type includes and before `acf/init` fires.
+
+3. **Runtime filter registration**
+   - Register one new filter:
+     - `render_block` → `SCF_Post_Content_Placeholders::filter_render_block()`
+
+4. **No save/editor bootstrap additions**
+   - Do not add hooks for block serialization, `save_post`, editor JS, REST formatting, or broad `the_content` replacement.
+
+5. **Possible internal extension filters**
+   - Only add `scf/...` filters if needed to encapsulate internal policy without widening the default scope.
+
+# Data flow changes
+
+1. WordPress renders a post through the normal frontend singular `the_content` pipeline.
+2. Each Gutenberg block passes through `render_block`.
+3. The new service receives rendered block HTML and the parsed block array.
+4. The service returns early unless the render matches the approved v1 runtime and block constraints.
+5. For supported paragraph/heading block HTML containing `[[`, the service scans for exact placeholders.
+6. The service deduplicates matched field names per block.
+7. For each unique field name, the service:
+   - checks cache for the current post ID
+   - temporarily enables `acf/prevent_access_to_unknown_fields` if not already enabled
+   - calls `get_field_object()` for the current post
+   - validates type allowlist and `allow_in_bindings`
+   - ensures the resolved formatted value is scalar and non-empty
+   - sanitizes the final string through placeholder-specific inline KSES
+   - stores the final string or empty string in cache
+8. The service replaces exact placeholder matches in block HTML with the resolved sanitized strings.
+9. The rendered post continues through the normal output pipeline.
+10. Stored `post_content` remains unchanged throughout.
+
+# Sanitization and security tasks
+
+1. **Unknown-field access hardening**
+   - Reuse the existing shortcode-style `acf/prevent_access_to_unknown_fields` pattern during placeholder resolution.
+   - Ensure temporary filter removal happens reliably after lookup.
+
+2. **Supported type enforcement**
+   - Implement the approved explicit allowlist only:
+     - `text`
+     - `textarea`
+     - `number`
+     - `range`
+     - `email`
+     - `url`
+     - `select` when scalar
+     - `radio`
+     - `button_group`
+     - `date_picker`
+     - `date_time_picker`
+     - `time_picker`
+     - `wysiwyg`
+
+3. **Public-display enforcement**
+   - Require `allow_in_bindings` to be present and truthy.
+   - Treat missing or false values as denied output.
+
+4. **Scalar-only enforcement**
+   - Reject arrays, objects, and other non-scalar outputs.
+   - Treat multi-select/array-like outputs as unsupported for this render.
+
+5. **Inline-only HTML sanitization**
+   - Use a fixed `wp_kses()` allowlist for:
+     - `a[href,target,rel,title]`
+     - `abbr[title]`
+     - `b`, `br`, `cite`, `code`, `del`, `em`, `i`, `mark`, `small`, `strong`, `sub`, `sup`
+   - Explicitly exclude `span`, `class`, `style`, `id`, `data-*`, event attributes, and all block-level tags.
+
+6. **Silent failure behavior**
+   - Exact placeholders with missing/denied/unsupported/empty results must render `''`.
+   - Malformed tokens must remain literal.
+   - No user-facing warnings, comments, or debug strings should be injected.
+
+7. **No unsafe execution paths**
+   - Do not evaluate shortcodes, scripts, embeds, event handlers, or arbitrary HTML as part of placeholder output.
+
+# Test plan
+
+## PHPUnit
+
+Run targeted tests for the new class first, then broader PHP coverage if needed:
+
+```bash
+composer test:php -- --filter Post_Content_Placeholders
+# or
+vendor/bin/phpunit tests/php/includes/test-scf-post-content-placeholders.php
+```
+
+Minimum PHPUnit assertions:
+
+- supported placeholder replacement in paragraph output
+- supported placeholder replacement in heading output
+- repeated placeholders produce same output
+- malformed tokens remain unchanged
+- missing fields resolve empty
+- unsupported block names are untouched
+- unsupported runtime gates are untouched
+- unsupported field types resolve empty
+- missing/false `allow_in_bindings` resolves empty
+- safe inline HTML is preserved
+- block-level/disallowed tags are stripped
+- array/non-scalar values resolve empty
+
+## E2E
+
+Run the focused Playwright spec through the required npm wrapper:
+
+```bash
+npm run test:e2e -- tests/e2e/post-content-placeholders.spec.ts
+```
+
+Minimum E2E assertions:
+
+- placeholder survives save/reopen in Gutenberg
+- frontend paragraph replacement works
+- frontend heading replacement works
+- malformed token remains raw on frontend
+- unsupported/denied field renders empty
+- unsupported context remains raw
+- deactivation reveals original raw placeholder text
+
+## Optional quality checks
+
+If implementation touches multiple files or triggers formatting issues:
+
+```bash
+composer lint:php
+npx wp-scripts lint-js
+```
+
+Only run JS lint if helper/spec changes require it.
+
+# Rollout/verification steps
+
+1. Build the feature behind normal plugin initialization with no migration.
+2. Create a manual verification post with paragraph and heading placeholders.
+3. Confirm frontend singular rendering replaces supported placeholders.
+4. Confirm the editor still shows raw `[[field_name]]` text after reopen/resave.
+5. Confirm excerpts/REST/feed behavior remains raw or otherwise untouched.
+6. Confirm a denied field (`allow_in_bindings` disabled) renders empty without warnings.
+7. Confirm a WYSIWYG field preserves safe inline markup but strips structural HTML.
+8. Deactivate the plugin and confirm raw placeholder text becomes visible again.
+9. If all tests and manual checks pass, the orchestrator can promote the approved plan and proceed to implementation.
+
+# Risks and dependencies
+
+## Risks
+
+1. **Legacy field behavior surprise**
+   - Existing fields may default to `allow_in_bindings` true in some stored contexts, while the design requires explicit presence + truthiness checks for placeholders. Implementation must follow the approved design exactly, and tests should document this behavior.
+
+2. **Context-gating edge cases**
+   - Theme/plugin variations in `render_block`, loop state, or content rendering order may reveal edge cases; the gate should remain conservative rather than trying to broaden support.
+
+3. **Sanitization surprises for WYSIWYG values**
+   - Users may expect full rich markup, but v1 intentionally strips block-level structure.
+
+4. **Test setup complexity**
+   - E2E setup may need careful field creation/configuration to ensure `allow_in_bindings` is enabled and predictable.
+
+## Dependencies
+
+- Existing SCF APIs, especially `get_field_object()` and field type registration in `ACF::init()`.
+- WordPress frontend block render pipeline via `render_block`.
+- Existing field setting `allow_in_bindings` behavior.
+- Existing PHPUnit bootstrap and E2E wp-env setup.
+
+# Out of scope
+
+- Replacing placeholders in excerpts, REST content, feeds, widgets, comments, or admin previews.
+- Supporting blocks beyond `core/paragraph` and `core/heading`.
+- Save-time content mutation or serialization changes.
+- Live editor preview/substitution while typing.
+- Cross-object lookups or field-key syntax.
+- Nested placeholders, fallback syntax, filters, or formatting directives.
+- Structured field rendering for repeaters, groups, images, files, relationships, or arbitrary arrays/objects.
+- User-facing UI for inserting or validating placeholders.
+
+# Open questions
+
+1. During implementation, do existing PHP test utilities already provide a clean pattern for simulating `render_block` in-loop singular contexts, or will the new test class need small custom setup?
+2. For E2E coverage of unsupported contexts, is excerpt rendering the simplest stable assertion, or is a REST response check more reliable in this repository’s test environment?
+3. If minor helper extraction is needed for E2E field setup, should it stay local to the new spec or be promoted into shared helpers after the first implementation lands?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v1.md
@@ -1,0 +1,34 @@
+Decision: DENY
+
+Why
+- The spec is directionally strong and substantially improved over a loose feature request, but it is not yet implementation-ready because several requirements that materially affect architecture, compatibility, and test scope are still unresolved.
+- The largest gap is render-context scope. The spec says v1 must replace placeholders on singular frontend content through the normal content pipeline, but the open questions still leave preview and REST-rendered contexts undecided. That matters for Gutenberg compatibility, because editor previews and other WordPress consumers may use those paths. An implementation cannot be cleanly scoped until the required and non-required render contexts are explicitly enumerated.
+- The field support contract is still ambiguous. The spec says v1 supports values whose formatted value resolves to a scalar string or number, but also asks whether support should be determined by field type allowlist versus final value shape. Those are different product and engineering choices with different maintenance costs and different test matrices. The spec must choose one.
+- Sanitization requirements are not sufficiently precise for HTML-bearing values. The spec says HTML string values may be supported after sanitization at the WordPress post-content allowlist level, but it leaves unresolved whether block-level markup from a WYSIWYG field is allowed inline or must be restricted. That ambiguity affects broken-markup risk, user expectations, and acceptance criteria.
+- Acceptance criteria are not fully measurable for supported contexts. Criterion 4 says placeholders work in “at least paragraph blocks and one additional text-based block type,” but the additional block type is unspecified. That is not testable as written and leaves too much discretion for implementation.
+- Backward-compatibility behavior is partly specified but still incomplete around non-frontend consumers. The spec correctly protects stored post_content and deactivation behavior, but it does not clearly state whether excerpts, feeds, REST responses, admin previews, or other consumers are intentionally out of scope for v1.
+- The malformed-token behavior is mostly clear, but the spec should explicitly define whether token matching is performed before or after normal content filters that may alter bracket characters or HTML entities. Without that, edge behavior may vary by hook placement.
+- Cost and support impact are slightly understated given the unresolved scope. Once contexts, field-type gating, and HTML rules are fixed, implementation may still be small-to-medium, but support cost could rise quickly if users expect broader block/editor/REST behavior than v1 actually ships.
+
+Cost notes
+- Current cost estimate is premature because the unresolved questions are not cosmetic; they define the implementation boundary.
+- Choosing a strict allowlist of supported field types and strict frontend-only scope would keep v1 closer to small/medium cost.
+- Allowing support based on final formatted value alone, or supporting preview/REST/editor-rendered contexts, increases compatibility testing, support burden, and maintenance risk.
+- Allowing block-level HTML from WYSIWYG-like fields inline raises markup and UX risk and likely increases implementation and testing cost.
+
+Required changes
+1. Resolve render-context scope explicitly. State whether v1 applies only to singular frontend `the_content`, or also to previews, excerpts, feeds, REST-rendered content, and editor preview paths. Any non-supported context should be explicitly listed as out of scope.
+2. Resolve the field support contract. Choose one of these and state it normatively:
+   - explicit allowlist of supported SCF field types in v1, or
+   - support determined solely by final resolved scalar/string output.
+   The current draft cannot leave both models in play.
+3. Tighten HTML output rules. State whether HTML-bearing values are allowed only when they remain inline-safe after sanitization, or whether block-level markup from WYSIWYG-like fields is intentionally supported inline. The spec should define the expected behavior, not leave it as an open question.
+4. Make acceptance criterion 4 measurable by naming the exact additional supported text-based block type, not “one additional text-based block type.”
+5. Clarify unsupported consumer behavior for excerpts/feeds/REST/admin preview/editor preview. If they are out of scope, say so in either requirements or out-of-scope.
+6. Clarify malformed/literal bracket handling enough to prevent overmatching. The draft should explicitly state that only exact `[[field_name]]` matches are replaced and all other bracketed text remains literal.
+7. Clarify observability expectations for unsupported fields and sanitization stripping. If v1 is intentionally silent to end users, say that explicitly so support and test expectations are aligned.
+8. Reconcile “implementation-ready” status with the open questions section. Either resolve the open questions into decisions for v1 or demote them so they do not affect architecture, acceptance criteria, or required test coverage.
+
+Next version expected
+- `spec-v2.md`
+- It should preserve the current narrow v1 scope, but convert the unresolved architectural/product choices above into explicit decisions so the design phase can proceed without guessing.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v2.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v2.md
@@ -1,0 +1,23 @@
+Decision: DENY
+
+Why
+- This revision resolves nearly all of the implementation-blocking ambiguities from v1. It now makes explicit decisions on render scope, unsupported contexts, exact-token matching, supported block types, HTML handling, and observability. The spec is much closer to implementation-ready.
+- However, I am still denying approval because the v1 field allowlist includes `password`, which creates an avoidable security/privacy risk that is not justified or mitigated by the spec.
+- A password-type field is commonly understood to contain sensitive or intentionally obscured values. Allowing exact `[[field_name]]` placeholders to render password field contents inline on the public frontend would make accidental disclosure significantly easier for editors/authors and would create support and security risk disproportionate to v1’s value.
+- The current draft’s safety language focuses on sanitization and code execution, but this problem is not an HTML-sanitization issue. It is a data-exposure issue. A value can be perfectly sanitized and still be the wrong thing to expose.
+- Because this feature is specifically about editorial inline reuse, the v1 supported-type list should be conservative. Including `password` weakens the spec’s security posture without being necessary to prove the feature concept.
+- Aside from that issue, the unresolved items from the prior denial were converted into explicit decisions and the spec is otherwise implementation-ready.
+
+Cost notes
+- Removing `password` from the allowlist lowers security review burden and support cost with negligible implementation cost.
+- Keeping `password` in scope would increase risk of accidental sensitive-data exposure and likely require additional product justification, documentation, and possibly capability/authoring safeguards that are out of proportion for a narrow v1.
+- All other scoping choices in this revision appropriately control engineering and maintenance cost for phase 2.
+
+Required changes
+1. Remove `password` from the v1 supported field-type allowlist.
+2. Add an explicit statement that fields intended to hold sensitive, secret, or non-public values are out of scope for v1 placeholder rendering.
+3. Ensure the acceptance criteria and any related assumptions remain aligned with the revised allowlist after `password` is removed.
+
+Next version expected
+- `spec-v3.md`
+- It should keep the current v2 structure and decisions, but tighten the security/privacy model by excluding password/sensitive-value fields from v1 support.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v3.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-review-v3.md
@@ -1,0 +1,31 @@
+Decision: APPROVE
+
+Why
+- This revision resolves the remaining blocker from v2 by removing `password` from the supported field-type allowlist and explicitly excluding sensitive, secret, private, obscured, credential-like, and otherwise non-public fields from v1 placeholder rendering.
+- The spec is now implementation-ready. It makes explicit, testable decisions on:
+  - exact placeholder syntax and literal-text preservation
+  - render-time-only replacement
+  - supported frontend render scope
+  - unsupported contexts
+  - supported Gutenberg block types for v1
+  - field support via explicit allowlist
+  - empty/malformed/unsupported handling
+  - sanitization and inline-safe HTML rules
+  - silent user-facing behavior
+  - backward compatibility and deactivation behavior
+- Security/privacy expectations are now appropriately conservative for a v1 feature. The spec distinguishes sanitization safety from data-exposure safety and keeps sensitive-value rendering out of scope.
+- Acceptance criteria are measurable and aligned with the stated scope. The spec gives phase 2 enough clarity to design architecture, hook placement, sanitization behavior, and test coverage without guessing.
+- The document is also aligned with repository conventions in `AGENTS.md`, especially around WordPress standards, backward compatibility expectations, and the need for automated coverage.
+
+Cost notes
+- The current scope is well controlled and realistic for a small-to-medium implementation.
+- Testing cost remains medium because the approved scope still requires both behavior verification and compatibility coverage across supported and intentionally unsupported contexts.
+- Support cost remains manageable because the spec is explicit about what v1 does not do, which should help prevent accidental scope creep in design and implementation.
+- Excluding sensitive/non-public fields lowers security review and support burden materially without reducing the core value of the experiment.
+
+Required changes
+- None.
+
+Next version expected
+- No further phase-1 spec revision required.
+- Proceed to phase 2 design doc based on `spec-v3.md`.

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v1.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v1.md
@@ -1,0 +1,142 @@
+# Task
+
+Create an implementation-ready specification for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Summary
+
+Add support for post-content placeholders using `[[field_name]]` syntax so authors can reference post-level Secure Custom Fields values inline inside Gutenberg-authored post content. Placeholder replacement must occur at render time without mutating stored `post_content`, must degrade safely when placeholders are invalid or values are unavailable, and must sanitize output according to WordPress standards.
+
+Version 1 of the feature is limited to post-level field lookups for the current post and to placeholders that resolve to scalar or HTML string output suitable for inline rendering.
+
+# Problem statement
+
+Authors can store reusable values in post-level custom fields, but they cannot currently reference those values directly inside post content without duplicating text, writing PHP templates, or creating custom blocks. This creates content drift, makes updates harder, and reduces the value of custom fields for editorial workflows.
+
+A placeholder syntax inside post content would let authors keep a single source of truth in custom fields while reusing those values in paragraphs and other text-based content areas.
+
+# Goals
+
+- Allow authors to type `[[field_name]]` directly into post content and have it render as the matching field value for the current post.
+- Support Gutenberg-authored content without changing how content is stored in the database.
+- Preserve raw placeholder text in saved content so plugin deactivation does not corrupt or rewrite content.
+- Sanitize rendered output according to WordPress core standards while preserving safe inline formatting.
+- Fail safely for missing, empty, malformed, or unsupported placeholders.
+- Define a narrow, testable v1 scope that can be shipped without introducing a broader templating language.
+
+# Functional requirements
+
+1. **Placeholder syntax**
+   - The feature must recognize placeholders written as `[[field_name]]`.
+   - `field_name` refers to a post-level custom field name saved against the current post.
+   - Supported field identifiers in v1 must be limited to simple field names composed of lowercase or uppercase letters, numbers, underscores, and hyphens.
+   - Placeholders containing spaces, nesting, additional operators, or unsupported characters must be treated as malformed.
+
+2. **Render-time behavior**
+   - Placeholder replacement must happen at render time only.
+   - Stored `post_content` in the database must remain exactly as authored, including the raw placeholder text.
+   - For a supported placeholder with a matching field value, the placeholder must be replaced inline with the rendered field output.
+   - Multiple placeholders may appear in the same post and in the same block content string.
+   - Repeated use of the same placeholder within one rendered post must produce the same output for that post render.
+
+3. **Supported scope and contexts**
+   - v1 must support placeholders authored inside Gutenberg post content.
+   - v1 must replace placeholders when singular post content for the current post is rendered through the normal WordPress content rendering pipeline on the frontend.
+   - v1 must support inline replacement inside paragraph blocks and other text-based blocks whose saved content passes through the standard post-content rendering pipeline.
+   - v1 must not require block serialization changes, block attribute schema changes, or content migrations.
+   - Gutenberg compatibility in v1 means authors can safely type and save placeholders in the block editor and receive resolved output on render; live RichText substitution while editing is not required.
+
+4. **Field value support**
+   - v1 must support post-level fields whose formatted value resolves to a scalar string or number suitable for inline output.
+   - v1 may support HTML-bearing string values, including WYSIWYG-like output, only after sanitization defined in this spec.
+   - Fields that resolve to arrays, objects, attachments, repeaters, galleries, relational collections, or other structured/non-scalar values must be treated as unsupported in v1.
+   - Unsupported field values must fail safely without PHP warnings, JavaScript errors, or broken markup.
+
+5. **Missing, empty, malformed, and unsupported placeholders**
+   - If the placeholder references a field that does not exist for the current post, the rendered output must be an empty string.
+   - If the placeholder references a field that exists but has no usable value, the rendered output must be an empty string.
+   - Empty output must be the default and only v1 behavior; no user setting is required in v1.
+   - Malformed placeholders must remain unchanged in rendered content so authors can see the original token they entered.
+   - Supported syntax that resolves to an unsupported field type must render as an empty string.
+
+6. **Sanitization and escaping**
+   - Rendered output must be sanitized before insertion into rendered content.
+   - Plain-text values must be escaped for safe HTML output.
+   - HTML-bearing string values must be sanitized using the WordPress post-content allowlist level, preserving safe inline markup such as emphasis and links while stripping unsafe markup.
+   - Disallowed tags, disallowed attributes, scripts, event handlers, forms, iframes, and malformed unsafe markup must not be rendered.
+   - Sanitization failures or malformed HTML must not crash rendering.
+
+7. **Backward compatibility and persistence**
+   - Existing content without placeholders must render unchanged.
+   - Existing content containing bracketed text that does not match the supported placeholder syntax must render unchanged.
+   - Deactivating Secure Custom Fields must not remove, rewrite, or corrupt saved post content.
+   - After plugin deactivation, raw placeholder text must remain visible because stored content is unchanged.
+
+8. **Extensibility expectations**
+   - v1 must not expose a user-facing UI picker for inserting placeholders.
+   - v1 may add internal extension points or filters only if they do not change the required default behavior in this spec.
+   - Any new public hooks introduced for this feature should prefer `scf/...` hook names unless backward compatibility requires an `acf_` pattern.
+
+# Non-functional requirements
+
+- **WordPress standards**: Implementation must follow WordPress core coding standards, plugin best practices, repository conventions in `AGENTS.md`, and SCF naming conventions.
+- **Safety**: The feature must never execute arbitrary PHP, shortcodes, JavaScript, or unsanitized HTML from field values.
+- **Performance**: Placeholder parsing and field lookup must be scoped to rendered post content and should avoid redundant lookups for repeated placeholders within the same content render.
+- **Reliability**: Missing data, invalid syntax, unsupported field types, and malformed field HTML must not generate fatal errors, notices visible to users, or invalid block storage.
+- **Editor stability**: The block editor must continue to load, save, and reopen posts containing placeholders without validation errors caused by this feature.
+- **Testability**: Behavior must be covered by automated tests for successful replacement, empty handling, malformed placeholders, sanitization, and deactivation-safe persistence.
+
+# Acceptance criteria
+
+1. A user can type `[[movie_title]]` into Gutenberg paragraph content, save the post, and see the matching current post field value rendered inline on the frontend.
+2. The raw saved `post_content` in the database still contains `[[movie_title]]` rather than the resolved field value.
+3. A post containing multiple placeholders in the same paragraph renders each supported placeholder with the correct current post field value.
+4. Placeholder replacement works in at least paragraph blocks and one additional text-based block type that uses normal saved post content rendering.
+5. A placeholder referencing a missing field renders no output and does not produce PHP errors, JS errors, or broken page markup.
+6. A placeholder referencing an empty field renders no output and does not leave unsafe or broken markup.
+7. A malformed token such as `[[movie title]]`, `[[movie_title]`, or `[[movie_title|upper]]` remains unchanged in rendered content.
+8. A placeholder that resolves to an unsupported non-scalar field value renders no output and does not display raw `Array`, serialized data, or PHP warnings.
+9. A field value containing safe inline HTML such as `<strong>` or `<em>` renders with that formatting preserved after sanitization.
+10. A field value containing unsafe HTML such as `<script>` or disallowed attributes is sanitized so unsafe content is not rendered.
+11. Deactivating the plugin does not rewrite or corrupt saved post content; the frontend shows the original raw placeholder text because replacement no longer runs.
+12. Posts containing placeholders can be reopened in the block editor and resaved without block corruption introduced by this feature.
+
+# Out of scope
+
+- Cross-post, cross-user, cross-term, comment, or option-page field references.
+- Nested placeholders or a general templating language.
+- Conditional logic, fallback text, transforms, filters, or formatting directives inside placeholder syntax.
+- A block-editor UI picker, autocomplete, or inserter for placeholders.
+- Rendering structured field types such as repeaters, groups, galleries, images, files, relationship collections, or arbitrary arrays/objects.
+- Per-placeholder, per-block, or global settings for empty-value display behavior.
+- Live inline substitution inside the editable RichText canvas while the user is typing.
+- Automatic migration of existing shortcodes, merge tags, or other token syntaxes.
+
+# Assumptions
+
+- The current post context is available at render time for the supported frontend content pipeline.
+- SCF field values can be retrieved by field name for the current post using existing SCF/ACF field APIs.
+- WordPress post-content sanitization primitives are sufficient for v1 HTML safety requirements.
+- Gutenberg-authored paragraph and similar text blocks persist literal placeholder text without additional escaping that would prevent server-side replacement on render.
+- Shipping a narrow scalar/string-focused v1 is acceptable even though the issue discusses broader custom-field usage.
+
+# Risks
+
+- Overly broad token matching could accidentally alter content that users intended as literal bracketed text.
+- Rendering HTML-bearing field values inline may still create layout surprises if block contexts expect plain text.
+- Some field types may return formatted output that appears scalar but is unsuitable for inline insertion unless further constrained in implementation.
+- Hook placement in the content pipeline may affect previews, excerpts, REST-rendered content, or other consumers differently than expected.
+- Unsupported structured fields may create user confusion if placeholders silently render empty without editor guidance.
+
+# Cost
+
+- **Implementation size**: Small to medium.
+- **Complexity drivers**: safe token parsing, field-type gating, HTML sanitization, Gutenberg/frontend compatibility, and automated coverage.
+- **Testing cost**: Medium, because the feature needs PHP/unit coverage plus E2E coverage for Gutenberg authoring, frontend rendering, and deactivation-safe persistence.
+
+# Open questions
+
+1. Should v1 replacement run only on singular frontend content, or also in preview/REST-rendered contexts where block editor previews may consume rendered post content?
+2. Should field lookup support only field names in v1, or also field keys when the token syntax matches a field key?
+3. Should unsupported structured field placeholders render empty silently, or should SCF expose a developer-only debug signal or hook for observability?
+4. Do we want an explicit allowlist of supported SCF field types in v1, or should support be determined strictly by the final resolved value being scalar/string?
+5. If a supported field value contains block-level HTML (for example, paragraph tags from a WYSIWYG field), should v1 allow it inline after sanitization or restrict output to inline-safe markup only?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v2.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v2.md
@@ -1,0 +1,189 @@
+# Task
+
+Create an implementation-ready specification for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Summary
+
+Add support for post-content placeholders using exact `[[field_name]]` syntax so authors can reference post-level Secure Custom Fields values inline inside Gutenberg-authored post content. Placeholder replacement must occur at render time without mutating stored `post_content`, must degrade safely when placeholders are invalid or values are unavailable, and must sanitize output according to WordPress standards.
+
+Version 1 is intentionally narrow. It applies only to singular frontend post-content rendering for the current post, supports only a defined allowlist of text-capable post field types, preserves only inline-safe HTML, and leaves all non-exact bracketed text untouched.
+
+# Problem statement
+
+Authors can store reusable values in post-level custom fields, but they cannot currently reference those values directly inside post content without duplicating text, writing PHP templates, or creating custom blocks. This creates content drift, makes updates harder, and reduces the value of custom fields for editorial workflows.
+
+A placeholder syntax inside post content would let authors keep a single source of truth in custom fields while reusing those values in paragraphs and other text-based content areas.
+
+# Goals
+
+- Allow authors to type exact `[[field_name]]` placeholders directly into post content and have them render as the matching field value for the current post.
+- Support Gutenberg-authored content without changing how content is stored in the database.
+- Preserve raw placeholder text in saved content so plugin deactivation does not corrupt or rewrite content.
+- Sanitize rendered output according to WordPress core standards while preserving safe inline formatting.
+- Fail safely for missing, empty, malformed, or unsupported placeholders.
+- Define a narrow, testable v1 scope with explicit render contexts, supported field types, and HTML rules.
+
+# Functional requirements
+
+1. **Placeholder syntax**
+   - The feature must recognize placeholders written in the exact form `[[field_name]]`.
+   - `field_name` refers to a post-level custom field name saved against the current post.
+   - Supported field identifiers in v1 must be limited to letters, numbers, underscores, and hyphens.
+   - Only exact matches to the `[[field_name]]` pattern are eligible for replacement.
+   - Any bracketed text that does not exactly match the supported pattern must remain literal and unchanged in rendered output.
+   - Examples that must remain unchanged include `[[movie title]]`, `[[movie_title]`, `[movie_title]`, `[[movie_title|upper]]`, nested tokens, and escaped or entity-altered bracket text that no longer appears as an exact placeholder at replacement time.
+
+2. **Render-time behavior**
+   - Placeholder replacement must happen at render time only.
+   - Stored `post_content` in the database must remain exactly as authored, including the raw placeholder text.
+   - For a supported placeholder with a matching supported field value, the placeholder must be replaced inline with the rendered field output.
+   - Multiple placeholders may appear in the same post and in the same block content string.
+   - Repeated use of the same placeholder within one rendered post must produce the same output for that post render.
+   - Placeholder matching for v1 must operate on the content string as received by the replacement callback in the chosen frontend render path; if earlier filters have transformed the brackets so the exact placeholder text no longer exists, no replacement occurs.
+
+3. **Supported render scope and contexts**
+   - v1 must support placeholders authored inside Gutenberg post content.
+   - v1 must replace placeholders only when singular post content for the current post is rendered on the frontend through the standard `the_content` pipeline.
+   - v1 must support inline replacement inside these exact Gutenberg block types when their saved content is rendered through that pipeline:
+     - Paragraph (`core/paragraph`)
+     - Heading (`core/heading`)
+   - v1 Gutenberg compatibility means authors can safely type, save, reopen, and publish placeholders in the block editor, and can see resolved output on the frontend after save.
+   - v1 does not require live RichText substitution while editing, block validation-time substitution, or block serialization changes.
+
+4. **Non-supported render contexts in v1**
+   - The following contexts are intentionally out of scope for placeholder replacement in v1 unless they happen to render via the same supported singular frontend `the_content` path and receive the same callback behavior:
+     - post excerpts
+     - feeds
+     - REST API content fields
+     - admin list tables
+     - admin edit-form previews outside normal saved frontend viewing
+     - block editor live editing canvas substitution
+     - block editor preview mechanisms that do not use the supported singular frontend `the_content` path
+     - widgets, comments, term descriptions, user profiles, option pages, and non-post objects
+   - In these non-supported contexts, placeholder text may remain raw and this is acceptable v1 behavior.
+
+5. **Field support contract**
+   - v1 field support is determined by an explicit allowlist of SCF field types, not by arbitrary final value shape.
+   - The supported field types in v1 are:
+     - `text`
+     - `textarea`
+     - `number`
+     - `range`
+     - `email`
+     - `url`
+     - `password`
+     - `select` when the resolved value is a single scalar value
+     - `radio`
+     - `button_group`
+     - `date_picker`
+     - `date_time_picker`
+     - `time_picker`
+     - `wysiwyg`
+   - For supported field types, the resolved formatted value must still be scalar string/number output before sanitization and insertion.
+   - Supported field types that return arrays, objects, or other non-scalar results in a given configuration must be treated as unsupported for that render and must output an empty string.
+   - Field keys, option values, term fields, user fields, comment fields, and cross-object lookups are not supported in v1.
+
+6. **Missing, empty, malformed, and unsupported placeholders**
+   - If the placeholder references a field that does not exist for the current post, the rendered output must be an empty string.
+   - If the placeholder references a supported field that exists but has no usable value, the rendered output must be an empty string.
+   - Empty output is the default and only v1 behavior; no user setting is required in v1.
+   - Malformed placeholders must remain unchanged in rendered content so authors can see the original token they entered.
+   - Exact-syntax placeholders that resolve to unsupported field types or unsupported non-scalar values must render as an empty string.
+   - These cases must not produce PHP warnings, JavaScript errors, visible admin notices to end users, or broken page markup.
+
+7. **Sanitization and escaping**
+   - Rendered output must be sanitized before insertion into rendered content.
+   - Plain-text values must be escaped for safe HTML output.
+   - HTML-bearing values are permitted only for supported string-returning fields and only when the final rendered output is safe for inline insertion.
+   - Allowed HTML behavior in v1 is limited to inline-safe markup that survives WordPress post-content sanitization, such as emphasis, strong text, links, code, and line-break-level inline formatting.
+   - Block-level HTML output is not supported in v1 placeholder rendering. If a field value contains block-level or layout-producing markup such as `<p>`, headings, lists, tables, block wrappers, embeds, iframes, forms, scripts, or similar structural elements, that markup must not be rendered as block output through placeholder replacement.
+   - For HTML-bearing values from supported fields such as `wysiwyg`, v1 must sanitize the value and then preserve only the inline-safe subset for insertion. Any disallowed or block-level markup must be stripped rather than rendered.
+   - Disallowed tags, disallowed attributes, scripts, event handlers, forms, iframes, and malformed unsafe markup must not be rendered.
+   - Sanitization failures or malformed HTML must not crash rendering.
+
+8. **Observability and user-facing silence**
+   - v1 must be silent to end users for missing fields, empty fields, unsupported fields, and sanitization stripping.
+   - v1 must not inject fallback text, HTML comments, debug text, or visible warnings into post content for these cases.
+   - v1 is not required to expose a user-facing notice, editor warning, or developer debug panel for unsupported placeholders or stripped HTML.
+   - Internal logging or future developer hooks may be added later, but no such observability is required for v1 and no acceptance criteria depend on it.
+
+9. **Backward compatibility and persistence**
+   - Existing content without placeholders must render unchanged.
+   - Existing content containing bracketed text that does not match the supported placeholder syntax must render unchanged.
+   - Deactivating Secure Custom Fields must not remove, rewrite, or corrupt saved post content.
+   - After plugin deactivation, raw placeholder text must remain visible because stored content is unchanged and replacement no longer runs.
+
+10. **Extensibility expectations**
+   - v1 must not expose a user-facing UI picker for inserting placeholders.
+   - v1 may add internal extension points or filters only if they do not change the required default behavior in this spec.
+   - Any new public hooks introduced for this feature should prefer `scf/...` hook names unless backward compatibility requires an `acf_` pattern.
+
+# Non-functional requirements
+
+- **WordPress standards**: Implementation must follow WordPress core coding standards, plugin best practices, repository conventions in `AGENTS.md`, and SCF naming conventions.
+- **Safety**: The feature must never execute arbitrary PHP, shortcodes, JavaScript, or unsanitized HTML from field values.
+- **Performance**: Placeholder parsing and field lookup must be scoped to supported singular frontend post renders and should avoid redundant lookups for repeated placeholders within the same content render.
+- **Reliability**: Missing data, invalid syntax, unsupported field types, unsupported value shapes, and malformed field HTML must not generate fatal errors, notices visible to users, or invalid block storage.
+- **Editor stability**: The block editor must continue to load, save, and reopen posts containing placeholders without validation errors caused by this feature.
+- **Determinism**: Only exact placeholders are replaced; all other bracketed text must remain literal so authors can predict output.
+- **Testability**: Behavior must be covered by automated tests for successful replacement, empty handling, malformed placeholders, unsupported contexts, sanitization, and deactivation-safe persistence.
+
+# Acceptance criteria
+
+1. A user can type `[[movie_title]]` into a Gutenberg paragraph block, save the post, and see the matching current post field value rendered inline on the frontend singular post view.
+2. The raw saved `post_content` in the database still contains `[[movie_title]]` rather than the resolved field value.
+3. A post containing multiple placeholders in the same paragraph renders each supported placeholder with the correct current post field value.
+4. Placeholder replacement works in both Paragraph (`core/paragraph`) and Heading (`core/heading`) blocks when rendered on the frontend singular post view through the supported content pipeline.
+5. A placeholder referencing a missing field renders no output and does not produce PHP errors, JS errors, or broken page markup.
+6. A placeholder referencing an empty field renders no output and does not leave unsafe or broken markup.
+7. A malformed or non-exact token such as `[[movie title]]`, `[[movie_title]`, `[movie_title]`, or `[[movie_title|upper]]` remains unchanged in rendered content.
+8. A placeholder that resolves to an unsupported field type or unsupported non-scalar value renders no output and does not display raw `Array`, serialized data, or PHP warnings.
+9. A supported field value containing safe inline HTML such as `<strong>`, `<em>`, or a safe `<a>` renders with that formatting preserved after sanitization.
+10. A supported field value containing unsafe HTML such as `<script>` or disallowed attributes is sanitized so unsafe content is not rendered.
+11. A supported HTML-bearing field value containing block-level markup such as `<p>` or `<ul>` does not render that structural markup through placeholder replacement; only the inline-safe sanitized subset, if any, is inserted.
+12. Placeholder text remains raw in at least one explicitly unsupported v1 context, such as an excerpt or REST content response, confirming that unsupported consumer behavior is non-replacement rather than content mutation.
+13. Deactivating the plugin does not rewrite or corrupt saved post content; the frontend shows the original raw placeholder text because replacement no longer runs.
+14. Posts containing placeholders can be reopened in the block editor and resaved without block corruption introduced by this feature.
+
+# Out of scope
+
+- Cross-post, cross-user, cross-term, comment, or option-page field references.
+- Field-key token lookup or any token syntax other than exact `[[field_name]]` matches.
+- Nested placeholders or a general templating language.
+- Conditional logic, fallback text, transforms, filters, or formatting directives inside placeholder syntax.
+- A block-editor UI picker, autocomplete, or inserter for placeholders.
+- Rendering structured field types such as repeaters, groups, galleries, images, files, relationship collections, or arbitrary arrays/objects.
+- Per-placeholder, per-block, or global settings for empty-value display behavior.
+- Live inline substitution inside the editable RichText canvas while the user is typing.
+- Replacement in excerpts, feeds, REST responses, admin previews, or other non-supported contexts listed above.
+- Automatic migration of existing shortcodes, merge tags, or other token syntaxes.
+
+# Assumptions
+
+- The current singular post context is available during the supported frontend `the_content` render path.
+- SCF field values can be retrieved by field name for the current post using existing SCF/ACF field APIs.
+- Gutenberg-authored Paragraph and Heading blocks persist literal placeholder text without additional escaping that prevents server-side replacement on the supported render path.
+- WordPress sanitization primitives are sufficient to reduce supported HTML-bearing values to an inline-safe subset for v1.
+- A narrow explicit allowlist of supported field types is acceptable for the first release of this feature.
+
+# Risks
+
+- Users may expect replacement in previews, REST responses, or excerpts because the raw token syntax is visible in those contexts, but v1 intentionally does not guarantee support there.
+- Even with sanitization, stripping block-level HTML from WYSIWYG values may surprise users who expect full rich content embedding.
+- Hook placement in the content pipeline may still create edge cases if third-party filters alter bracket text before replacement runs.
+- Silent empty output for unsupported or missing fields may reduce discoverability of authoring mistakes without future editor assistance.
+
+# Cost
+
+- **Implementation size**: Small to medium.
+- **Complexity drivers**: exact token parsing, explicit render-scope enforcement, supported field-type allowlist handling, inline-safe HTML sanitization, and automated coverage across supported and unsupported contexts.
+- **Testing cost**: Medium, because the feature needs PHP/unit coverage plus E2E coverage for Gutenberg authoring, frontend rendering, unsupported contexts, sanitization behavior, and deactivation-safe persistence.
+- **Support cost**: Medium, because users may request broader editor, REST, preview, and structured-field support beyond the intentionally narrow v1 scope.
+
+# Open questions
+
+1. Should a future version add editor affordances such as placeholder autocomplete, insertion UI, or validation messaging for unsupported field references?
+2. Should a future version expand replacement beyond singular frontend `the_content` to previews, excerpts, feeds, or REST-rendered content?
+3. Should a future version support additional scalar-like field types beyond the v1 allowlist, or add a broader developer opt-in mechanism?
+4. Should a future version provide optional observability such as developer hooks, logs, or editor notices when placeholders resolve empty or HTML is stripped?
+5. Should a future version introduce richer syntax such as fallback text or formatting directives, while preserving backward compatibility with exact `[[field_name]]` tokens?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v3.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec-v3.md
@@ -1,0 +1,190 @@
+# Task
+
+Create an implementation-ready specification for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Summary
+
+Add support for post-content placeholders using exact `[[field_name]]` syntax so authors can reference post-level Secure Custom Fields values inline inside Gutenberg-authored post content. Placeholder replacement must occur at render time without mutating stored `post_content`, must degrade safely when placeholders are invalid or values are unavailable, and must sanitize output according to WordPress standards.
+
+Version 1 is intentionally narrow. It applies only to singular frontend post-content rendering for the current post, supports only a defined allowlist of text-capable post field types, excludes fields intended to store sensitive or non-public values, preserves only inline-safe HTML, and leaves all non-exact bracketed text untouched.
+
+# Problem statement
+
+Authors can store reusable values in post-level custom fields, but they cannot currently reference those values directly inside post content without duplicating text, writing PHP templates, or creating custom blocks. This creates content drift, makes updates harder, and reduces the value of custom fields for editorial workflows.
+
+A placeholder syntax inside post content would let authors keep a single source of truth in custom fields while reusing those values in paragraphs and other text-based content areas.
+
+# Goals
+
+- Allow authors to type exact `[[field_name]]` placeholders directly into post content and have them render as the matching field value for the current post.
+- Support Gutenberg-authored content without changing how content is stored in the database.
+- Preserve raw placeholder text in saved content so plugin deactivation does not corrupt or rewrite content.
+- Sanitize rendered output according to WordPress core standards while preserving safe inline formatting.
+- Fail safely for missing, empty, malformed, or unsupported placeholders.
+- Define a narrow, testable v1 scope with explicit render contexts, supported field types, HTML rules, and conservative data-exposure boundaries.
+
+# Functional requirements
+
+1. **Placeholder syntax**
+   - The feature must recognize placeholders written in the exact form `[[field_name]]`.
+   - `field_name` refers to a post-level custom field name saved against the current post.
+   - Supported field identifiers in v1 must be limited to letters, numbers, underscores, and hyphens.
+   - Only exact matches to the `[[field_name]]` pattern are eligible for replacement.
+   - Any bracketed text that does not exactly match the supported pattern must remain literal and unchanged in rendered output.
+   - Examples that must remain unchanged include `[[movie title]]`, `[[movie_title]`, `[movie_title]`, `[[movie_title|upper]]`, nested tokens, and escaped or entity-altered bracket text that no longer appears as an exact placeholder at replacement time.
+
+2. **Render-time behavior**
+   - Placeholder replacement must happen at render time only.
+   - Stored `post_content` in the database must remain exactly as authored, including the raw placeholder text.
+   - For a supported placeholder with a matching supported field value, the placeholder must be replaced inline with the rendered field output.
+   - Multiple placeholders may appear in the same post and in the same block content string.
+   - Repeated use of the same placeholder within one rendered post must produce the same output for that post render.
+   - Placeholder matching for v1 must operate on the content string as received by the replacement callback in the chosen frontend render path; if earlier filters have transformed the brackets so the exact placeholder text no longer exists, no replacement occurs.
+
+3. **Supported render scope and contexts**
+   - v1 must support placeholders authored inside Gutenberg post content.
+   - v1 must replace placeholders only when singular post content for the current post is rendered on the frontend through the standard `the_content` pipeline.
+   - v1 must support inline replacement inside these exact Gutenberg block types when their saved content is rendered through that pipeline:
+     - Paragraph (`core/paragraph`)
+     - Heading (`core/heading`)
+   - v1 Gutenberg compatibility means authors can safely type, save, reopen, and publish placeholders in the block editor, and can see resolved output on the frontend after save.
+   - v1 does not require live RichText substitution while editing, block validation-time substitution, or block serialization changes.
+
+4. **Non-supported render contexts in v1**
+   - The following contexts are intentionally out of scope for placeholder replacement in v1 unless they happen to render via the same supported singular frontend `the_content` path and receive the same callback behavior:
+     - post excerpts
+     - feeds
+     - REST API content fields
+     - admin list tables
+     - admin edit-form previews outside normal saved frontend viewing
+     - block editor live editing canvas substitution
+     - block editor preview mechanisms that do not use the supported singular frontend `the_content` path
+     - widgets, comments, term descriptions, user profiles, option pages, and non-post objects
+   - In these non-supported contexts, placeholder text may remain raw and this is acceptable v1 behavior.
+
+5. **Field support contract**
+   - v1 field support is determined by an explicit allowlist of SCF field types, not by arbitrary final value shape.
+   - The supported field types in v1 are:
+     - `text`
+     - `textarea`
+     - `number`
+     - `range`
+     - `email`
+     - `url`
+     - `select` when the resolved value is a single scalar value
+     - `radio`
+     - `button_group`
+     - `date_picker`
+     - `date_time_picker`
+     - `time_picker`
+     - `wysiwyg`
+   - For supported field types, the resolved formatted value must still be scalar string/number output before sanitization and insertion.
+   - Supported field types that return arrays, objects, or other non-scalar results in a given configuration must be treated as unsupported for that render and must output an empty string.
+   - Fields intended to hold sensitive, secret, private, obscured, credential-like, or otherwise non-public values are out of scope for v1 placeholder rendering, even if their stored type might otherwise appear text-like.
+   - Field keys, option values, term fields, user fields, comment fields, and cross-object lookups are not supported in v1.
+
+6. **Missing, empty, malformed, and unsupported placeholders**
+   - If the placeholder references a field that does not exist for the current post, the rendered output must be an empty string.
+   - If the placeholder references a supported field that exists but has no usable value, the rendered output must be an empty string.
+   - Empty output is the default and only v1 behavior; no user setting is required in v1.
+   - Malformed placeholders must remain unchanged in rendered content so authors can see the original token they entered.
+   - Exact-syntax placeholders that resolve to unsupported field types, sensitive/non-public fields, or unsupported non-scalar values must render as an empty string.
+   - These cases must not produce PHP warnings, JavaScript errors, visible admin notices to end users, or broken page markup.
+
+7. **Sanitization and escaping**
+   - Rendered output must be sanitized before insertion into rendered content.
+   - Plain-text values must be escaped for safe HTML output.
+   - HTML-bearing values are permitted only for supported string-returning fields and only when the final rendered output is safe for inline insertion.
+   - Allowed HTML behavior in v1 is limited to inline-safe markup that survives WordPress post-content sanitization, such as emphasis, strong text, links, code, and line-break-level inline formatting.
+   - Block-level HTML output is not supported in v1 placeholder rendering. If a field value contains block-level or layout-producing markup such as `<p>`, headings, lists, tables, block wrappers, embeds, iframes, forms, scripts, or similar structural elements, that markup must not be rendered as block output through placeholder replacement.
+   - For HTML-bearing values from supported fields such as `wysiwyg`, v1 must sanitize the value and then preserve only the inline-safe subset for insertion. Any disallowed or block-level markup must be stripped rather than rendered.
+   - Disallowed tags, disallowed attributes, scripts, event handlers, forms, iframes, and malformed unsafe markup must not be rendered.
+   - Sanitization failures or malformed HTML must not crash rendering.
+
+8. **Observability and user-facing silence**
+   - v1 must be silent to end users for missing fields, empty fields, unsupported fields, sensitive/non-public fields, and sanitization stripping.
+   - v1 must not inject fallback text, HTML comments, debug text, or visible warnings into post content for these cases.
+   - v1 is not required to expose a user-facing notice, editor warning, or developer debug panel for unsupported placeholders or stripped HTML.
+   - Internal logging or future developer hooks may be added later, but no such observability is required for v1 and no acceptance criteria depend on it.
+
+9. **Backward compatibility and persistence**
+   - Existing content without placeholders must render unchanged.
+   - Existing content containing bracketed text that does not match the supported placeholder syntax must render unchanged.
+   - Deactivating Secure Custom Fields must not remove, rewrite, or corrupt saved post content.
+   - After plugin deactivation, raw placeholder text must remain visible because stored content is unchanged and replacement no longer runs.
+
+10. **Extensibility expectations**
+   - v1 must not expose a user-facing UI picker for inserting placeholders.
+   - v1 may add internal extension points or filters only if they do not change the required default behavior in this spec.
+   - Any new public hooks introduced for this feature should prefer `scf/...` hook names unless backward compatibility requires an `acf_` pattern.
+
+# Non-functional requirements
+
+- **WordPress standards**: Implementation must follow WordPress core coding standards, plugin best practices, repository conventions in `AGENTS.md`, and SCF naming conventions.
+- **Safety**: The feature must never execute arbitrary PHP, shortcodes, JavaScript, unsanitized HTML, or expose intentionally non-public field values through placeholder rendering.
+- **Performance**: Placeholder parsing and field lookup must be scoped to supported singular frontend post renders and should avoid redundant lookups for repeated placeholders within the same content render.
+- **Reliability**: Missing data, invalid syntax, unsupported field types, unsupported value shapes, sensitive-field exclusions, and malformed field HTML must not generate fatal errors, notices visible to users, or invalid block storage.
+- **Editor stability**: The block editor must continue to load, save, and reopen posts containing placeholders without validation errors caused by this feature.
+- **Determinism**: Only exact placeholders are replaced; all other bracketed text must remain literal so authors can predict output.
+- **Testability**: Behavior must be covered by automated tests for successful replacement, empty handling, malformed placeholders, unsupported contexts, sensitive-field exclusion, sanitization, and deactivation-safe persistence.
+
+# Acceptance criteria
+
+1. A user can type `[[movie_title]]` into a Gutenberg paragraph block, save the post, and see the matching current post field value rendered inline on the frontend singular post view.
+2. The raw saved `post_content` in the database still contains `[[movie_title]]` rather than the resolved field value.
+3. A post containing multiple placeholders in the same paragraph renders each supported placeholder with the correct current post field value.
+4. Placeholder replacement works in both Paragraph (`core/paragraph`) and Heading (`core/heading`) blocks when rendered on the frontend singular post view through the supported content pipeline.
+5. A placeholder referencing a missing field renders no output and does not produce PHP errors, JS errors, or broken page markup.
+6. A placeholder referencing an empty field renders no output and does not leave unsafe or broken markup.
+7. A malformed or non-exact token such as `[[movie title]]`, `[[movie_title]`, `[movie_title]`, or `[[movie_title|upper]]` remains unchanged in rendered content.
+8. A placeholder that resolves to an unsupported field type, a sensitive/non-public field, or an unsupported non-scalar value renders no output and does not display raw `Array`, serialized data, or PHP warnings.
+9. A supported field value containing safe inline HTML such as `<strong>`, `<em>`, or a safe `<a>` renders with that formatting preserved after sanitization.
+10. A supported field value containing unsafe HTML such as `<script>` or disallowed attributes is sanitized so unsafe content is not rendered.
+11. A supported HTML-bearing field value containing block-level markup such as `<p>` or `<ul>` does not render that structural markup through placeholder replacement; only the inline-safe sanitized subset, if any, is inserted.
+12. Placeholder text remains raw in at least one explicitly unsupported v1 context, such as an excerpt or REST content response, confirming that unsupported consumer behavior is non-replacement rather than content mutation.
+13. Deactivating the plugin does not rewrite or corrupt saved post content; the frontend shows the original raw placeholder text because replacement no longer runs.
+14. Posts containing placeholders can be reopened in the block editor and resaved without block corruption introduced by this feature.
+
+# Out of scope
+
+- Cross-post, cross-user, cross-term, comment, or option-page field references.
+- Field-key token lookup or any token syntax other than exact `[[field_name]]` matches.
+- Rendering fields intended to hold sensitive, secret, private, obscured, credential-like, or otherwise non-public values.
+- Nested placeholders or a general templating language.
+- Conditional logic, fallback text, transforms, filters, or formatting directives inside placeholder syntax.
+- A block-editor UI picker, autocomplete, or inserter for placeholders.
+- Rendering structured field types such as repeaters, groups, galleries, images, files, relationship collections, or arbitrary arrays/objects.
+- Per-placeholder, per-block, or global settings for empty-value display behavior.
+- Live inline substitution inside the editable RichText canvas while the user is typing.
+- Replacement in excerpts, feeds, REST responses, admin previews, or other non-supported contexts listed above.
+- Automatic migration of existing shortcodes, merge tags, or other token syntaxes.
+
+# Assumptions
+
+- The current singular post context is available during the supported frontend `the_content` render path.
+- SCF field values can be retrieved by field name for the current post using existing SCF/ACF field APIs.
+- Gutenberg-authored Paragraph and Heading blocks persist literal placeholder text without additional escaping that prevents server-side replacement on the supported render path.
+- WordPress sanitization primitives are sufficient to reduce supported HTML-bearing values to an inline-safe subset for v1.
+- A narrow explicit allowlist of supported non-sensitive field types is acceptable for the first release of this feature.
+
+# Risks
+
+- Users may expect replacement in previews, REST responses, or excerpts because the raw token syntax is visible in those contexts, but v1 intentionally does not guarantee support there.
+- Even with sanitization, stripping block-level HTML from WYSIWYG values may surprise users who expect full rich content embedding.
+- Hook placement in the content pipeline may still create edge cases if third-party filters alter bracket text before replacement runs.
+- Silent empty output for unsupported, missing, or sensitive fields may reduce discoverability of authoring mistakes without future editor assistance.
+
+# Cost
+
+- **Implementation size**: Small to medium.
+- **Complexity drivers**: exact token parsing, explicit render-scope enforcement, supported field-type allowlist handling, sensitive-field exclusion, inline-safe HTML sanitization, and automated coverage across supported and unsupported contexts.
+- **Testing cost**: Medium, because the feature needs PHP/unit coverage plus E2E coverage for Gutenberg authoring, frontend rendering, unsupported contexts, sensitive-field exclusion, sanitization behavior, and deactivation-safe persistence.
+- **Support cost**: Medium, because users may request broader editor, REST, preview, structured-field, and sensitive-field support beyond the intentionally narrow v1 scope.
+
+# Open questions
+
+1. Should a future version add editor affordances such as placeholder autocomplete, insertion UI, or validation messaging for unsupported field references?
+2. Should a future version expand replacement beyond singular frontend `the_content` to previews, excerpts, feeds, or REST-rendered content?
+3. Should a future version support additional scalar-like field types beyond the v1 allowlist, or add a broader developer opt-in mechanism?
+4. Should a future version provide optional observability such as developer hooks, logs, or editor notices when placeholders resolve empty or HTML is stripped?
+5. Should a future version introduce richer syntax such as fallback text or formatting directives, while preserving backward compatibility with exact `[[field_name]]` tokens?

--- a/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec.md
+++ b/examples/secure-custom-fields/issue-419-gutenberg-custom-field-placeholders/spec.md
@@ -1,0 +1,190 @@
+# Task
+
+Create an implementation-ready specification for GitHub issue #419, "Experiment: Add Gutenberg-compatible custom field placeholders for post content."
+
+# Summary
+
+Add support for post-content placeholders using exact `[[field_name]]` syntax so authors can reference post-level Secure Custom Fields values inline inside Gutenberg-authored post content. Placeholder replacement must occur at render time without mutating stored `post_content`, must degrade safely when placeholders are invalid or values are unavailable, and must sanitize output according to WordPress standards.
+
+Version 1 is intentionally narrow. It applies only to singular frontend post-content rendering for the current post, supports only a defined allowlist of text-capable post field types, excludes fields intended to store sensitive or non-public values, preserves only inline-safe HTML, and leaves all non-exact bracketed text untouched.
+
+# Problem statement
+
+Authors can store reusable values in post-level custom fields, but they cannot currently reference those values directly inside post content without duplicating text, writing PHP templates, or creating custom blocks. This creates content drift, makes updates harder, and reduces the value of custom fields for editorial workflows.
+
+A placeholder syntax inside post content would let authors keep a single source of truth in custom fields while reusing those values in paragraphs and other text-based content areas.
+
+# Goals
+
+- Allow authors to type exact `[[field_name]]` placeholders directly into post content and have them render as the matching field value for the current post.
+- Support Gutenberg-authored content without changing how content is stored in the database.
+- Preserve raw placeholder text in saved content so plugin deactivation does not corrupt or rewrite content.
+- Sanitize rendered output according to WordPress core standards while preserving safe inline formatting.
+- Fail safely for missing, empty, malformed, or unsupported placeholders.
+- Define a narrow, testable v1 scope with explicit render contexts, supported field types, HTML rules, and conservative data-exposure boundaries.
+
+# Functional requirements
+
+1. **Placeholder syntax**
+   - The feature must recognize placeholders written in the exact form `[[field_name]]`.
+   - `field_name` refers to a post-level custom field name saved against the current post.
+   - Supported field identifiers in v1 must be limited to letters, numbers, underscores, and hyphens.
+   - Only exact matches to the `[[field_name]]` pattern are eligible for replacement.
+   - Any bracketed text that does not exactly match the supported pattern must remain literal and unchanged in rendered output.
+   - Examples that must remain unchanged include `[[movie title]]`, `[[movie_title]`, `[movie_title]`, `[[movie_title|upper]]`, nested tokens, and escaped or entity-altered bracket text that no longer appears as an exact placeholder at replacement time.
+
+2. **Render-time behavior**
+   - Placeholder replacement must happen at render time only.
+   - Stored `post_content` in the database must remain exactly as authored, including the raw placeholder text.
+   - For a supported placeholder with a matching supported field value, the placeholder must be replaced inline with the rendered field output.
+   - Multiple placeholders may appear in the same post and in the same block content string.
+   - Repeated use of the same placeholder within one rendered post must produce the same output for that post render.
+   - Placeholder matching for v1 must operate on the content string as received by the replacement callback in the chosen frontend render path; if earlier filters have transformed the brackets so the exact placeholder text no longer exists, no replacement occurs.
+
+3. **Supported render scope and contexts**
+   - v1 must support placeholders authored inside Gutenberg post content.
+   - v1 must replace placeholders only when singular post content for the current post is rendered on the frontend through the standard `the_content` pipeline.
+   - v1 must support inline replacement inside these exact Gutenberg block types when their saved content is rendered through that pipeline:
+     - Paragraph (`core/paragraph`)
+     - Heading (`core/heading`)
+   - v1 Gutenberg compatibility means authors can safely type, save, reopen, and publish placeholders in the block editor, and can see resolved output on the frontend after save.
+   - v1 does not require live RichText substitution while editing, block validation-time substitution, or block serialization changes.
+
+4. **Non-supported render contexts in v1**
+   - The following contexts are intentionally out of scope for placeholder replacement in v1 unless they happen to render via the same supported singular frontend `the_content` path and receive the same callback behavior:
+     - post excerpts
+     - feeds
+     - REST API content fields
+     - admin list tables
+     - admin edit-form previews outside normal saved frontend viewing
+     - block editor live editing canvas substitution
+     - block editor preview mechanisms that do not use the supported singular frontend `the_content` path
+     - widgets, comments, term descriptions, user profiles, option pages, and non-post objects
+   - In these non-supported contexts, placeholder text may remain raw and this is acceptable v1 behavior.
+
+5. **Field support contract**
+   - v1 field support is determined by an explicit allowlist of SCF field types, not by arbitrary final value shape.
+   - The supported field types in v1 are:
+     - `text`
+     - `textarea`
+     - `number`
+     - `range`
+     - `email`
+     - `url`
+     - `select` when the resolved value is a single scalar value
+     - `radio`
+     - `button_group`
+     - `date_picker`
+     - `date_time_picker`
+     - `time_picker`
+     - `wysiwyg`
+   - For supported field types, the resolved formatted value must still be scalar string/number output before sanitization and insertion.
+   - Supported field types that return arrays, objects, or other non-scalar results in a given configuration must be treated as unsupported for that render and must output an empty string.
+   - Fields intended to hold sensitive, secret, private, obscured, credential-like, or otherwise non-public values are out of scope for v1 placeholder rendering, even if their stored type might otherwise appear text-like.
+   - Field keys, option values, term fields, user fields, comment fields, and cross-object lookups are not supported in v1.
+
+6. **Missing, empty, malformed, and unsupported placeholders**
+   - If the placeholder references a field that does not exist for the current post, the rendered output must be an empty string.
+   - If the placeholder references a supported field that exists but has no usable value, the rendered output must be an empty string.
+   - Empty output is the default and only v1 behavior; no user setting is required in v1.
+   - Malformed placeholders must remain unchanged in rendered content so authors can see the original token they entered.
+   - Exact-syntax placeholders that resolve to unsupported field types, sensitive/non-public fields, or unsupported non-scalar values must render as an empty string.
+   - These cases must not produce PHP warnings, JavaScript errors, visible admin notices to end users, or broken page markup.
+
+7. **Sanitization and escaping**
+   - Rendered output must be sanitized before insertion into rendered content.
+   - Plain-text values must be escaped for safe HTML output.
+   - HTML-bearing values are permitted only for supported string-returning fields and only when the final rendered output is safe for inline insertion.
+   - Allowed HTML behavior in v1 is limited to inline-safe markup that survives WordPress post-content sanitization, such as emphasis, strong text, links, code, and line-break-level inline formatting.
+   - Block-level HTML output is not supported in v1 placeholder rendering. If a field value contains block-level or layout-producing markup such as `<p>`, headings, lists, tables, block wrappers, embeds, iframes, forms, scripts, or similar structural elements, that markup must not be rendered as block output through placeholder replacement.
+   - For HTML-bearing values from supported fields such as `wysiwyg`, v1 must sanitize the value and then preserve only the inline-safe subset for insertion. Any disallowed or block-level markup must be stripped rather than rendered.
+   - Disallowed tags, disallowed attributes, scripts, event handlers, forms, iframes, and malformed unsafe markup must not be rendered.
+   - Sanitization failures or malformed HTML must not crash rendering.
+
+8. **Observability and user-facing silence**
+   - v1 must be silent to end users for missing fields, empty fields, unsupported fields, sensitive/non-public fields, and sanitization stripping.
+   - v1 must not inject fallback text, HTML comments, debug text, or visible warnings into post content for these cases.
+   - v1 is not required to expose a user-facing notice, editor warning, or developer debug panel for unsupported placeholders or stripped HTML.
+   - Internal logging or future developer hooks may be added later, but no such observability is required for v1 and no acceptance criteria depend on it.
+
+9. **Backward compatibility and persistence**
+   - Existing content without placeholders must render unchanged.
+   - Existing content containing bracketed text that does not match the supported placeholder syntax must render unchanged.
+   - Deactivating Secure Custom Fields must not remove, rewrite, or corrupt saved post content.
+   - After plugin deactivation, raw placeholder text must remain visible because stored content is unchanged and replacement no longer runs.
+
+10. **Extensibility expectations**
+   - v1 must not expose a user-facing UI picker for inserting placeholders.
+   - v1 may add internal extension points or filters only if they do not change the required default behavior in this spec.
+   - Any new public hooks introduced for this feature should prefer `scf/...` hook names unless backward compatibility requires an `acf_` pattern.
+
+# Non-functional requirements
+
+- **WordPress standards**: Implementation must follow WordPress core coding standards, plugin best practices, repository conventions in `AGENTS.md`, and SCF naming conventions.
+- **Safety**: The feature must never execute arbitrary PHP, shortcodes, JavaScript, unsanitized HTML, or expose intentionally non-public field values through placeholder rendering.
+- **Performance**: Placeholder parsing and field lookup must be scoped to supported singular frontend post renders and should avoid redundant lookups for repeated placeholders within the same content render.
+- **Reliability**: Missing data, invalid syntax, unsupported field types, unsupported value shapes, sensitive-field exclusions, and malformed field HTML must not generate fatal errors, notices visible to users, or invalid block storage.
+- **Editor stability**: The block editor must continue to load, save, and reopen posts containing placeholders without validation errors caused by this feature.
+- **Determinism**: Only exact placeholders are replaced; all other bracketed text must remain literal so authors can predict output.
+- **Testability**: Behavior must be covered by automated tests for successful replacement, empty handling, malformed placeholders, unsupported contexts, sensitive-field exclusion, sanitization, and deactivation-safe persistence.
+
+# Acceptance criteria
+
+1. A user can type `[[movie_title]]` into a Gutenberg paragraph block, save the post, and see the matching current post field value rendered inline on the frontend singular post view.
+2. The raw saved `post_content` in the database still contains `[[movie_title]]` rather than the resolved field value.
+3. A post containing multiple placeholders in the same paragraph renders each supported placeholder with the correct current post field value.
+4. Placeholder replacement works in both Paragraph (`core/paragraph`) and Heading (`core/heading`) blocks when rendered on the frontend singular post view through the supported content pipeline.
+5. A placeholder referencing a missing field renders no output and does not produce PHP errors, JS errors, or broken page markup.
+6. A placeholder referencing an empty field renders no output and does not leave unsafe or broken markup.
+7. A malformed or non-exact token such as `[[movie title]]`, `[[movie_title]`, `[movie_title]`, or `[[movie_title|upper]]` remains unchanged in rendered content.
+8. A placeholder that resolves to an unsupported field type, a sensitive/non-public field, or an unsupported non-scalar value renders no output and does not display raw `Array`, serialized data, or PHP warnings.
+9. A supported field value containing safe inline HTML such as `<strong>`, `<em>`, or a safe `<a>` renders with that formatting preserved after sanitization.
+10. A supported field value containing unsafe HTML such as `<script>` or disallowed attributes is sanitized so unsafe content is not rendered.
+11. A supported HTML-bearing field value containing block-level markup such as `<p>` or `<ul>` does not render that structural markup through placeholder replacement; only the inline-safe sanitized subset, if any, is inserted.
+12. Placeholder text remains raw in at least one explicitly unsupported v1 context, such as an excerpt or REST content response, confirming that unsupported consumer behavior is non-replacement rather than content mutation.
+13. Deactivating the plugin does not rewrite or corrupt saved post content; the frontend shows the original raw placeholder text because replacement no longer runs.
+14. Posts containing placeholders can be reopened in the block editor and resaved without block corruption introduced by this feature.
+
+# Out of scope
+
+- Cross-post, cross-user, cross-term, comment, or option-page field references.
+- Field-key token lookup or any token syntax other than exact `[[field_name]]` matches.
+- Rendering fields intended to hold sensitive, secret, private, obscured, credential-like, or otherwise non-public values.
+- Nested placeholders or a general templating language.
+- Conditional logic, fallback text, transforms, filters, or formatting directives inside placeholder syntax.
+- A block-editor UI picker, autocomplete, or inserter for placeholders.
+- Rendering structured field types such as repeaters, groups, galleries, images, files, relationship collections, or arbitrary arrays/objects.
+- Per-placeholder, per-block, or global settings for empty-value display behavior.
+- Live inline substitution inside the editable RichText canvas while the user is typing.
+- Replacement in excerpts, feeds, REST responses, admin previews, or other non-supported contexts listed above.
+- Automatic migration of existing shortcodes, merge tags, or other token syntaxes.
+
+# Assumptions
+
+- The current singular post context is available during the supported frontend `the_content` render path.
+- SCF field values can be retrieved by field name for the current post using existing SCF/ACF field APIs.
+- Gutenberg-authored Paragraph and Heading blocks persist literal placeholder text without additional escaping that prevents server-side replacement on the supported render path.
+- WordPress sanitization primitives are sufficient to reduce supported HTML-bearing values to an inline-safe subset for v1.
+- A narrow explicit allowlist of supported non-sensitive field types is acceptable for the first release of this feature.
+
+# Risks
+
+- Users may expect replacement in previews, REST responses, or excerpts because the raw token syntax is visible in those contexts, but v1 intentionally does not guarantee support there.
+- Even with sanitization, stripping block-level HTML from WYSIWYG values may surprise users who expect full rich content embedding.
+- Hook placement in the content pipeline may still create edge cases if third-party filters alter bracket text before replacement runs.
+- Silent empty output for unsupported, missing, or sensitive fields may reduce discoverability of authoring mistakes without future editor assistance.
+
+# Cost
+
+- **Implementation size**: Small to medium.
+- **Complexity drivers**: exact token parsing, explicit render-scope enforcement, supported field-type allowlist handling, sensitive-field exclusion, inline-safe HTML sanitization, and automated coverage across supported and unsupported contexts.
+- **Testing cost**: Medium, because the feature needs PHP/unit coverage plus E2E coverage for Gutenberg authoring, frontend rendering, unsupported contexts, sensitive-field exclusion, sanitization behavior, and deactivation-safe persistence.
+- **Support cost**: Medium, because users may request broader editor, REST, preview, structured-field, and sensitive-field support beyond the intentionally narrow v1 scope.
+
+# Open questions
+
+1. Should a future version add editor affordances such as placeholder autocomplete, insertion UI, or validation messaging for unsupported field references?
+2. Should a future version expand replacement beyond singular frontend `the_content` to previews, excerpts, feeds, or REST-rendered content?
+3. Should a future version support additional scalar-like field types beyond the v1 allowlist, or add a broader developer opt-in mechanism?
+4. Should a future version provide optional observability such as developer hooks, logs, or editor notices when placeholders resolve empty or HTML is stripped?
+5. Should a future version introduce richer syntax such as fallback text or formatting directives, while preserving backward compatibility with exact `[[field_name]]` tokens?


### PR DESCRIPTION
## Summary
- add a real Radical Pipelines example based on Secure Custom Fields issue 419
- include spec, design, and implementation-plan revisions plus canonical approved artifacts
- link the example from the main README

## Testing
- not run (documentation/example-only change)
