### PR TITLE
Create setup to populate project conventions

### DIFF
--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -48,15 +48,15 @@ To find the project-specific conventions, try the following in order:
 
 1. Shared project instructions already in your context or in project-root `AGENTS.md`.
 2. A dedicated conventions skill called `rp-conventions` or similar, when one is available.
-3. The Radical Pipelines `rp.md` file for the active agent tool, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+3. The Radical Pipelines `rp.md` file in the active CLI's project configuration folder, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-When reading conventions, distinguish shared cross-agent project instructions from agent tool-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. Agent tool-specific Radical Pipelines details belong in the active tool's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
+When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. CLI-specific Radical Pipelines details belong in the active CLI's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
 
 ### Missing conventions
 
 If all required conventions are available, continue the workflow unchanged.
 
-If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup-project-conventions.md`, explain what is missing, and offer to run the setup flow. The setup flow must collect the missing information, write reusable Markdown guidance to the active agent tool's conventions file when the owner confirms, and then stop or continue only after the conventions are complete.
+If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup-project-conventions.md`, explain what is missing, and offer to run the setup flow. The setup flow must collect the missing information, write reusable Markdown guidance to the active CLI's conventions file when the owner confirms, and then stop or continue only after the conventions are complete.
 
 If the owner declines setup, cancels, or leaves required answers unresolved, stop and clearly explain what is still missing. Do not create an incomplete conventions file unless the owner explicitly asks for a draft and the unresolved items are clearly marked.
 

--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -48,15 +48,15 @@ To find the project-specific conventions, try the following in order:
 
 1. Shared project instructions already in your context or in project-root `AGENTS.md`.
 2. A dedicated conventions skill called `rp-conventions` or similar, when one is available.
-3. The Radical Pipelines `rp.md` file in the active CLI's project configuration folder, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+3. The Radical Pipelines `rp.md` file for the active agent tool, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. CLI-specific Radical Pipelines details belong in the active CLI's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
+When reading conventions, distinguish shared cross-agent project instructions from agent tool-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. Agent tool-specific Radical Pipelines details belong in the active tool's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
 
 ### Missing conventions
 
 If all required conventions are available, continue the workflow unchanged.
 
-If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup-project-conventions.md`, explain what is missing, and offer to run the setup flow. The setup flow must collect the missing information, write reusable Markdown guidance to the active CLI's conventions file when the owner confirms, and then stop or continue only after the conventions are complete.
+If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup-project-conventions.md`, explain what is missing, and offer to run the setup flow. The setup flow must collect the missing information, write reusable Markdown guidance to the active agent tool's conventions file when the owner confirms, and then stop or continue only after the conventions are complete.
 
 If the owner declines setup, cancels, or leaves required answers unresolved, stop and clearly explain what is still missing. Do not create an incomplete conventions file unless the owner explicitly asks for a draft and the unresolved items are clearly marked.
 

--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -40,16 +40,25 @@ This skill is generic, but each project has its own conventions that you must fo
 - Spawning teams of agents
 - Commits
 
-This information is necessary to execute the pipelines correctly, so you must read it before starting any workflow.
+This information is necessary to execute the pipelines correctly, so you must load and verify it before starting any workflow.
+
+### Loading conventions
 
 To find the project-specific conventions, try the following in order:
 
-- Already in your context (e.g., injected via `AGENTS.md` file or custom skill).
-- The `AGENTS.md` file.
-- A skill called `rp-conventions` or similar.
-- The `rp.md` file on your CLI specific folder (`.claude/rp.md`, `.pi/rp.md`, etc).
+1. Shared project instructions already in your context or in project-root `AGENTS.md`.
+2. A dedicated conventions skill called `rp-conventions` or similar, when one is available.
+3. The Radical Pipelines `rp.md` file in the active CLI's project configuration folder, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-If any convention is missing, ask the owner before proceeding and then offer them to add it to the project for future reference.
+When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. CLI-specific Radical Pipelines details belong in the active CLI's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
+
+### Missing conventions
+
+If all required conventions are available, continue the workflow unchanged.
+
+If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup-project-conventions.md`, explain what is missing, and offer to run the setup flow. The setup flow must collect the missing information, write reusable Markdown guidance to the active CLI's conventions file when the owner confirms, and then stop or continue only after the conventions are complete.
+
+If the owner declines setup, cancels, or leaves required answers unresolved, stop and clearly explain what is still missing. Do not create an incomplete conventions file unless the owner explicitly asks for a draft and the unresolved items are clearly marked.
 
 ## Workflows
 
@@ -58,3 +67,4 @@ Before executing any workflow, you must read the corresponding reference file(s)
 | When the owner wants to... | Read                               |
 | -------------------------- | ---------------------------------- |
 | Start work on a pipeline   | `reference/starting-a-pipeline.md` |
+| Set up missing conventions | `reference/setup-project-conventions.md` |

--- a/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
+++ b/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
@@ -1,0 +1,106 @@
+# Setting Up Project Conventions
+
+Use this setup flow when required Radical Pipelines project conventions are missing before a workflow starts.
+
+## 1. Stop and explain
+
+Do not continue the pipeline. Tell the owner:
+
+- Radical Pipelines requires project conventions before it can run.
+- Which conventions were found and where they came from.
+- Which required conventions are still missing.
+- Shared cross-agent project instructions belong in project-root `AGENTS.md`.
+- CLI-specific Radical Pipelines conventions belong in the active CLI conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+
+Ask whether the owner wants to run setup now. If they decline or cancel, stop and summarize the missing conventions.
+
+## 2. Identify the active CLI target
+
+Determine the active agent CLI and target conventions file:
+
+| CLI | Target file |
+| --- | ----------- |
+| Pi | `.pi/rp.md` |
+| Claude Code | `.claude/rp.md` |
+| Other CLI | That CLI's project config folder, using an `rp.md` file when applicable |
+
+Create the parent configuration folder only after the owner confirms the setup answers should be written.
+
+## 3. Inspect shared instruction files
+
+Check whether project-root `AGENTS.md` exists and whether it already contains shared cross-agent guidance. Treat it as the canonical location for shared project instructions.
+
+If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that pointer. Do not replace it with copied instructions and do not write Radical Pipelines CLI-specific conventions into it. If `CLAUDE.md` is missing and the owner wants Claude Code to load shared instructions, you may suggest creating a thin pointer to `AGENTS.md`, but only create it after explicit confirmation.
+
+If `AGENTS.md` is missing and shared cross-agent instructions are needed, ask whether to create it. Do not create, overwrite, or replace `AGENTS.md` or `CLAUDE.md` without explicit confirmation.
+
+## 4. Collect required conventions
+
+Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or CLI-specific Radical Pipelines guidance for the active `rp.md` file.
+
+1. **Tasks:** Where tasks are tracked and how agents should access them.
+2. **Pipeline slugs:** The slug format to use for pipeline names.
+3. **Worktrees:** Whether worktrees are used and the exact commands or workflow for creating, entering, and removing them.
+4. **Branch names:** How branch names are chosen or created.
+5. **Pipeline artifact folders:** Where pipeline artifacts are stored.
+6. **Spawning teams of agents:** How this CLI should spawn teams or agents.
+7. **Commits:** Commit message format and any other commit rules.
+
+If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into every CLI-specific conventions file.
+
+## 5. Confirm writes before changing files
+
+Before writing anything, summarize the proposed file changes and ask for explicit confirmation.
+
+- If the active CLI `rp.md` file does not exist, ask before creating it.
+- If it exists, ask before overwriting it. Offer to merge or append only when the owner explicitly chooses that approach.
+- If `AGENTS.md` or `CLAUDE.md` would be created or changed, ask for separate explicit confirmation for each shared instruction file.
+
+If any required answer is missing, do not create a misleading complete conventions file. Either stop and explain what is unresolved, or, only if the owner explicitly asks for a draft, write a file that clearly marks unresolved items and state that setup is incomplete.
+
+## 6. Write human-readable Markdown
+
+Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Use clear sections such as:
+
+```markdown
+## Managing tasks
+
+...
+
+## Pipeline slugs
+
+...
+
+## Worktrees
+
+...
+
+## Branch names
+
+...
+
+## Pipeline artifact folders
+
+...
+
+## Spawning teams of agents
+
+...
+
+## Commits
+
+...
+```
+
+Do not duplicate general project instructions already present in `AGENTS.md`.
+
+## 7. Finish safely
+
+After setup completes, tell the owner:
+
+- Which files were created or updated.
+- That future Radical Pipelines runs in the same CLI should read the generated `rp.md` and skip setup if all required conventions are present.
+- To review and commit the generated CLI-specific conventions file if it should be shared with the project.
+- To review and commit any `AGENTS.md` or `CLAUDE.md` changes separately as shared agent instructions.
+
+If setup was cancelled or incomplete, stop the pipeline and clearly list what remains missing.

--- a/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
+++ b/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
@@ -10,15 +10,15 @@ Do not continue the pipeline. Tell the owner:
 - Which conventions were found and where they came from.
 - Which required conventions are still missing.
 - Shared cross-agent project instructions belong in project-root `AGENTS.md`.
-- Agent tool-specific Radical Pipelines conventions belong in the active tool's conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+- CLI-specific Radical Pipelines conventions belong in the active CLI conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
 Ask whether the owner wants to run setup now. If they decline or cancel, stop and summarize the missing conventions.
 
-## 2. Identify the active agent tool target
+## 2. Identify the active CLI target
 
-Determine the active agent tool and target conventions file:
+Determine the active CLI and target conventions file:
 
-| Agent tool | Target file |
+| CLI | Target file |
 | --- | ----------- |
 | Pi | `.pi/rp.md` |
 | Claude Code | `.claude/rp.md` |
@@ -29,29 +29,29 @@ Create the parent configuration folder only after the owner confirms the setup a
 
 Check whether project-root `AGENTS.md` exists and whether it already contains shared cross-agent guidance. Treat it as the canonical location for shared project instructions.
 
-If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that pointer. Do not replace it with copied instructions and do not write Radical Pipelines agent tool-specific conventions into it. If `CLAUDE.md` is missing and the owner wants Claude Code to load shared instructions, you may suggest creating a thin pointer to `AGENTS.md`, but only create it after explicit confirmation.
+If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that pointer. Do not replace it with copied instructions and do not write Radical Pipelines CLI-specific conventions into it. If `CLAUDE.md` is missing and the owner wants Claude Code to load shared instructions, you may suggest creating a thin pointer to `AGENTS.md`, but only create it after explicit confirmation.
 
 If `AGENTS.md` is missing and shared cross-agent instructions are needed, ask whether to create it. Do not create, overwrite, or replace `AGENTS.md` or `CLAUDE.md` without explicit confirmation.
 
 ## 4. Collect required conventions
 
-Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or agent tool-specific Radical Pipelines guidance for the active `rp.md` file.
+Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or CLI-specific Radical Pipelines guidance for the active `rp.md` file.
 
 1. **Tasks:** Where tasks are tracked and how agents should access them.
 2. **Pipeline slugs:** The slug format to use for pipeline names.
 3. **Worktrees:** Whether worktrees are used and the exact commands or workflow for creating, entering, and removing them.
 4. **Branch names:** How branch names are chosen or created.
 5. **Pipeline artifact folders:** Where pipeline artifacts are stored.
-6. **Spawning teams of agents:** How the active agent tool should spawn teams or agents.
+6. **Spawning teams of agents:** How the active CLI should spawn teams or agents.
 7. **Commits:** Commit message format and any other commit rules.
 
-If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into agent tool-specific conventions files.
+If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into CLI-specific conventions files.
 
 ## 5. Confirm writes before changing files
 
 Before writing anything, summarize the proposed file changes and ask for explicit confirmation.
 
-- If the active agent tool's `rp.md` file does not exist, ask before creating it.
+- If the active CLI `rp.md` file does not exist, ask before creating it.
 - If it exists, ask before overwriting it. Offer to merge or append only when the owner explicitly chooses that approach.
 - If `AGENTS.md` or `CLAUDE.md` would be created or changed, ask for separate explicit confirmation for each shared instruction file.
 
@@ -59,7 +59,7 @@ If any required answer is missing, do not create a misleading complete conventio
 
 ## 6. Write human-readable Markdown
 
-Write the active agent tool's `rp.md` file with only Radical Pipelines conventions needed by that tool. Use clear sections such as:
+Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Use clear sections such as:
 
 ```markdown
 ## Managing tasks
@@ -98,8 +98,8 @@ Do not duplicate general project instructions already present in `AGENTS.md`.
 After setup completes, tell the owner:
 
 - Which files were created or updated.
-- That future Radical Pipelines runs with the same agent tool should read the generated `rp.md` and skip setup if all required conventions are present.
-- To review and commit the generated agent tool-specific conventions file if it should be shared with the project.
+- That future Radical Pipelines runs with the same CLI should read the generated `rp.md` and skip setup if all required conventions are present.
+- To review and commit the generated CLI-specific conventions file if it should be shared with the project.
 - To review and commit any `AGENTS.md` or `CLAUDE.md` changes separately as shared agent instructions.
 
 If setup was cancelled or incomplete, stop the pipeline and clearly list what remains missing.

--- a/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
+++ b/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
@@ -10,19 +10,18 @@ Do not continue the pipeline. Tell the owner:
 - Which conventions were found and where they came from.
 - Which required conventions are still missing.
 - Shared cross-agent project instructions belong in project-root `AGENTS.md`.
-- CLI-specific Radical Pipelines conventions belong in the active CLI conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+- Agent tool-specific Radical Pipelines conventions belong in the active tool's conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
 Ask whether the owner wants to run setup now. If they decline or cancel, stop and summarize the missing conventions.
 
-## 2. Identify the active CLI target
+## 2. Identify the active agent tool target
 
-Determine the active agent CLI and target conventions file:
+Determine the active agent tool and target conventions file:
 
-| CLI | Target file |
+| Agent tool | Target file |
 | --- | ----------- |
 | Pi | `.pi/rp.md` |
 | Claude Code | `.claude/rp.md` |
-| Other CLI | That CLI's project config folder, using an `rp.md` file when applicable |
 
 Create the parent configuration folder only after the owner confirms the setup answers should be written.
 
@@ -30,29 +29,29 @@ Create the parent configuration folder only after the owner confirms the setup a
 
 Check whether project-root `AGENTS.md` exists and whether it already contains shared cross-agent guidance. Treat it as the canonical location for shared project instructions.
 
-If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that pointer. Do not replace it with copied instructions and do not write Radical Pipelines CLI-specific conventions into it. If `CLAUDE.md` is missing and the owner wants Claude Code to load shared instructions, you may suggest creating a thin pointer to `AGENTS.md`, but only create it after explicit confirmation.
+If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that pointer. Do not replace it with copied instructions and do not write Radical Pipelines agent tool-specific conventions into it. If `CLAUDE.md` is missing and the owner wants Claude Code to load shared instructions, you may suggest creating a thin pointer to `AGENTS.md`, but only create it after explicit confirmation.
 
 If `AGENTS.md` is missing and shared cross-agent instructions are needed, ask whether to create it. Do not create, overwrite, or replace `AGENTS.md` or `CLAUDE.md` without explicit confirmation.
 
 ## 4. Collect required conventions
 
-Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or CLI-specific Radical Pipelines guidance for the active `rp.md` file.
+Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or agent tool-specific Radical Pipelines guidance for the active `rp.md` file.
 
 1. **Tasks:** Where tasks are tracked and how agents should access them.
 2. **Pipeline slugs:** The slug format to use for pipeline names.
 3. **Worktrees:** Whether worktrees are used and the exact commands or workflow for creating, entering, and removing them.
 4. **Branch names:** How branch names are chosen or created.
 5. **Pipeline artifact folders:** Where pipeline artifacts are stored.
-6. **Spawning teams of agents:** How this CLI should spawn teams or agents.
+6. **Spawning teams of agents:** How the active agent tool should spawn teams or agents.
 7. **Commits:** Commit message format and any other commit rules.
 
-If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into every CLI-specific conventions file.
+If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into agent tool-specific conventions files.
 
 ## 5. Confirm writes before changing files
 
 Before writing anything, summarize the proposed file changes and ask for explicit confirmation.
 
-- If the active CLI `rp.md` file does not exist, ask before creating it.
+- If the active agent tool's `rp.md` file does not exist, ask before creating it.
 - If it exists, ask before overwriting it. Offer to merge or append only when the owner explicitly chooses that approach.
 - If `AGENTS.md` or `CLAUDE.md` would be created or changed, ask for separate explicit confirmation for each shared instruction file.
 
@@ -60,7 +59,7 @@ If any required answer is missing, do not create a misleading complete conventio
 
 ## 6. Write human-readable Markdown
 
-Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Use clear sections such as:
+Write the active agent tool's `rp.md` file with only Radical Pipelines conventions needed by that tool. Use clear sections such as:
 
 ```markdown
 ## Managing tasks
@@ -99,8 +98,8 @@ Do not duplicate general project instructions already present in `AGENTS.md`.
 After setup completes, tell the owner:
 
 - Which files were created or updated.
-- That future Radical Pipelines runs in the same CLI should read the generated `rp.md` and skip setup if all required conventions are present.
-- To review and commit the generated CLI-specific conventions file if it should be shared with the project.
+- That future Radical Pipelines runs with the same agent tool should read the generated `rp.md` and skip setup if all required conventions are present.
+- To review and commit the generated agent tool-specific conventions file if it should be shared with the project.
 - To review and commit any `AGENTS.md` or `CLAUDE.md` changes separately as shared agent instructions.
 
 If setup was cancelled or incomplete, stop the pipeline and clearly list what remains missing.

--- a/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
@@ -1,6 +1,6 @@
 # Starting a Pipeline
 
-Before executing these steps, make sure you have loaded the project conventions (see `SKILL.md` → "Project conventions"). Each step below applies one of those conventions.
+Before executing these steps, make sure you have loaded and verified the project conventions (see `SKILL.md` → "Project conventions"). If any required convention is missing, stop and run the setup flow in `reference/setup-project-conventions.md` before continuing. Each step below applies one of those conventions.
 
 ## Steps
 

--- a/.pipelines/9-create-setup-to-populate-project-conventions/prompt.md
+++ b/.pipelines/9-create-setup-to-populate-project-conventions/prompt.md
@@ -1,0 +1,7 @@
+# Create setup to populate project conventions
+
+Implement support for setting up project conventions when the Radical Pipelines skill is loaded and no project conventions can be found.
+
+The setup should guide the user through the missing convention information with a series of questions, then create the conventions file from the answers so future pipeline runs can proceed without repeating the setup.
+
+Source task: https://github.com/Automattic/radical-pipelines/issues/9

--- a/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
+++ b/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
@@ -2,14 +2,20 @@
 
 ## Overview
 
-When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write a reusable conventions file. Future pipeline runs in the same project should be able to read that file and proceed without repeating setup.
+When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write reusable convention guidance in the correct place for the active agent CLI. Future pipeline runs in the same project should be able to read the generated guidance and proceed without repeating setup.
+
+The setup flow must follow the repository's existing conventions workflow instead of introducing a competing pattern. Shared, cross-agent project instructions belong in the project-root `AGENTS.md`. In this repository, `CLAUDE.md` is intentionally only a thin pointer to `AGENTS.md` (`@AGENTS.md`) and must stay that way. Radical Pipelines CLI-specific conventions belong in the active CLI's `rp.md` file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
 ## Requirements
 
 1. **Detect missing project conventions**
-   - When the Radical Pipelines skill is loaded for a pipeline workflow, it must try to find project-specific conventions using the existing documented lookup order.
+   - When the Radical Pipelines skill is loaded for a pipeline workflow, it must try to find project-specific conventions using the existing documented lookup order:
+     1. project-root `AGENTS.md` for shared project instructions;
+     2. a dedicated skill, when one is available;
+     3. the active CLI's `rp.md` conventions file, such as `.pi/rp.md` or `.claude/rp.md`.
    - If all required conventions are available, the workflow must continue unchanged.
    - If one or more required conventions are missing, the skill must not proceed with the pipeline until the missing information is supplied or the user cancels.
+   - Detection must distinguish shared cross-agent instructions from Radical Pipelines CLI-specific conventions, so missing CLI-specific data does not cause the setup to duplicate shared `AGENTS.md` content.
 
 2. **Offer an interactive setup flow**
    - When conventions are missing, the skill must explain that Radical Pipelines requires project conventions before it can run.
@@ -22,39 +28,58 @@ When a user starts a Radical Pipelines workflow in a project where project conve
      - pipeline artifact folder location;
      - how to spawn teams or agents;
      - commit message conventions.
+   - The setup must identify which answers are shared project instructions and which are CLI-specific Radical Pipelines conventions.
+   - If the user provides shared cross-agent guidance, the setup must recommend adding or updating project-root `AGENTS.md` rather than copying that guidance into each CLI-specific conventions file.
 
-3. **Create a conventions file**
+3. **Create or update the correct conventions file**
    - After collecting answers, the setup must create a conventions file in the current project's CLI-specific configuration folder when appropriate for the active agent CLI.
-   - For Pi, the generated file should be `.pi/rp.md`.
-   - For Claude Code, the generated file should be `.claude/rp.md`.
+   - For Pi, the generated Radical Pipelines conventions file should be `.pi/rp.md`.
+   - For Claude Code, the generated Radical Pipelines conventions file should be `.claude/rp.md`.
    - The generated file must be human-readable Markdown.
    - The generated file must organize the answers into sections that are easy for future agents to read.
    - The setup must create the parent configuration folder if it does not already exist.
+   - The generated CLI-specific file must contain only the conventions needed by Radical Pipelines for that CLI and must not duplicate general project instructions already present in `AGENTS.md`.
 
-4. **Make the generated conventions reusable**
-   - The generated file must contain enough information for future Radical Pipelines runs to satisfy the project conventions lookup without asking the same setup questions again.
+4. **Preserve the repository conventions pointer pattern**
+   - The setup must treat project-root `AGENTS.md` as the canonical location for shared, cross-agent project instructions.
+   - The setup must not expand this repository's `CLAUDE.md` into a full copy of `AGENTS.md`; when `CLAUDE.md` is used as a pointer file, it must preserve the thin pointer pattern (`@AGENTS.md`).
+   - The setup must not write Radical Pipelines CLI-specific setup details into `CLAUDE.md` when `.claude/rp.md` is the appropriate destination.
+   - If `CLAUDE.md` is missing in a project and the user wants Claude Code to load shared project instructions, the setup may suggest creating a thin pointer to `AGENTS.md` rather than duplicating the shared content.
+   - If `AGENTS.md` is missing and shared instructions are required, the setup must ask before creating it and must clearly separate that shared file from CLI-specific `rp.md` files.
+
+5. **Make the generated conventions reusable**
+   - The generated CLI-specific conventions file must contain enough information for future Radical Pipelines runs in that CLI to satisfy the project conventions lookup without asking the same setup questions again.
    - After writing the file, the skill must instruct the user to review and commit the generated conventions file if it should be shared with the project.
+   - If the setup also creates or recommends changes to `AGENTS.md` or a thin pointer `CLAUDE.md`, it must instruct the user to review and commit those files separately as shared agent instructions.
 
-5. **Handle partial or cancelled setup safely**
+6. **Handle partial or cancelled setup safely**
    - If the user declines setup or does not provide required answers, the skill must stop and explain what is still missing.
    - The setup must not create an incomplete conventions file unless it clearly marks unresolved items and tells the user the setup is incomplete.
    - The setup must not overwrite an existing conventions file without explicit user confirmation.
+   - The setup must not overwrite or replace an existing `AGENTS.md` or `CLAUDE.md` without explicit user confirmation.
+   - If an existing `CLAUDE.md` is a pointer to `AGENTS.md`, the setup must preserve that pointer unless the user explicitly requests a different pattern.
 
-6. **Update user-facing documentation**
+7. **Update user-facing documentation**
    - The README must describe the automatic setup behavior at a high level.
-   - The documentation must mention where generated conventions files are written for supported CLIs.
+   - The documentation must mention where generated Radical Pipelines conventions files are written for supported CLIs.
+   - The documentation must explain that shared project instructions should live in `AGENTS.md`, while CLI-specific Radical Pipelines conventions should live in `.pi/rp.md`, `.claude/rp.md`, or another active CLI equivalent.
+   - The documentation must mention that `CLAUDE.md` may be a thin pointer to `AGENTS.md` and that setup should not duplicate shared content into it.
 
 ## Acceptance criteria
 
 - Starting a Radical Pipelines workflow in a project with complete conventions continues without triggering setup.
 - Starting a workflow in a project with no discoverable conventions prompts the user to run the setup flow instead of failing silently or proceeding with assumptions.
 - The setup flow asks for all conventions required by the skill to run a pipeline.
-- Completing setup in Pi creates `.pi/rp.md` with the collected conventions in Markdown.
-- Completing setup in Claude Code creates `.claude/rp.md` with the collected conventions in Markdown.
+- Completing setup in Pi creates or updates `.pi/rp.md` with the collected Pi-specific Radical Pipelines conventions in Markdown.
+- Completing setup in Claude Code creates or updates `.claude/rp.md` with the collected Claude-specific Radical Pipelines conventions in Markdown.
+- The generated `rp.md` file does not copy general project guidance already present in `AGENTS.md`.
+- If shared project instructions are missing, the setup directs the user to `AGENTS.md` rather than putting shared guidance in CLI-specific files.
+- If `CLAUDE.md` is a thin pointer to `AGENTS.md`, setup preserves that pointer and does not replace it with duplicated content.
 - If the target conventions file already exists, the setup asks before overwriting it.
+- If `AGENTS.md` or `CLAUDE.md` would be created or changed, the setup asks for explicit confirmation first.
 - After setup completes, a subsequent Radical Pipelines workflow can use the generated conventions file without asking the same questions again.
 - If the user cancels or leaves required information unresolved, no misleading complete conventions file is produced and the workflow stops with a clear message.
-- README documentation is updated to describe the setup behavior and generated file locations.
+- README documentation is updated to describe the setup behavior, generated file locations, and the separation between shared `AGENTS.md` instructions, optional `CLAUDE.md` pointer files, and CLI-specific `rp.md` conventions.
 
 ## Out of scope
 
@@ -65,3 +90,5 @@ When a user starts a Radical Pipelines workflow in a project where project conve
 - Inferring all project conventions from repository history without user input.
 - Committing the generated conventions file automatically.
 - Changing the canonical list of required project conventions beyond what the current Radical Pipelines skill needs.
+- Replacing `AGENTS.md` with CLI-specific instruction files as the canonical shared project instructions location.
+- Expanding this repository's `CLAUDE.md` pointer into a full instructions document.

--- a/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
+++ b/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write reusable convention guidance in the correct place for the active agent CLI. Future pipeline runs in the same project should be able to read the generated guidance and proceed without repeating setup.
+When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write reusable convention guidance in the correct place for the active agent tool. Future pipeline runs in the same project should be able to read the generated guidance and proceed without repeating setup.
 
-The setup flow must follow the repository's existing conventions workflow instead of introducing a competing pattern. Shared, cross-agent project instructions belong in the project-root `AGENTS.md`. In this repository, `CLAUDE.md` is intentionally only a thin pointer to `AGENTS.md` (`@AGENTS.md`) and must stay that way. Radical Pipelines CLI-specific conventions belong in the active CLI's `rp.md` file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+The setup flow must follow the repository's existing conventions workflow instead of introducing a competing pattern. Shared, cross-agent project instructions belong in the project-root `AGENTS.md`. In this repository, `CLAUDE.md` is intentionally only a thin pointer to `AGENTS.md` (`@AGENTS.md`) and must stay that way. Radical Pipelines agent tool-specific conventions belong in the active tool's `rp.md` file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
 ## Requirements
 
@@ -12,10 +12,10 @@ The setup flow must follow the repository's existing conventions workflow instea
    - When the Radical Pipelines skill is loaded for a pipeline workflow, it must try to find project-specific conventions using the existing documented lookup order:
      1. project-root `AGENTS.md` for shared project instructions;
      2. a dedicated skill, when one is available;
-     3. the active CLI's `rp.md` conventions file, such as `.pi/rp.md` or `.claude/rp.md`.
+     3. the active agent tool's `rp.md` conventions file, such as `.pi/rp.md` or `.claude/rp.md`.
    - If all required conventions are available, the workflow must continue unchanged.
    - If one or more required conventions are missing, the skill must not proceed with the pipeline until the missing information is supplied or the user cancels.
-   - Detection must distinguish shared cross-agent instructions from Radical Pipelines CLI-specific conventions, so missing CLI-specific data does not cause the setup to duplicate shared `AGENTS.md` content.
+   - Detection must distinguish shared cross-agent instructions from Radical Pipelines agent tool-specific conventions, so missing tool-specific data does not cause the setup to duplicate shared `AGENTS.md` content.
 
 2. **Offer an interactive setup flow**
    - When conventions are missing, the skill must explain that Radical Pipelines requires project conventions before it can run.
@@ -28,27 +28,27 @@ The setup flow must follow the repository's existing conventions workflow instea
      - pipeline artifact folder location;
      - how to spawn teams or agents;
      - commit message conventions.
-   - The setup must identify which answers are shared project instructions and which are CLI-specific Radical Pipelines conventions.
-   - If the user provides shared cross-agent guidance, the setup must recommend adding or updating project-root `AGENTS.md` rather than copying that guidance into each CLI-specific conventions file.
+   - The setup must identify which answers are shared project instructions and which are agent tool-specific Radical Pipelines conventions.
+   - If the user provides shared cross-agent guidance, the setup must recommend adding or updating project-root `AGENTS.md` rather than copying that guidance into agent tool-specific conventions files.
 
 3. **Create or update the correct conventions file**
-   - After collecting answers, the setup must create a conventions file in the current project's CLI-specific configuration folder when appropriate for the active agent CLI.
+   - After collecting answers, the setup must create a conventions file in the current project's agent tool-specific configuration folder when appropriate for the active agent tool.
    - For Pi, the generated Radical Pipelines conventions file should be `.pi/rp.md`.
    - For Claude Code, the generated Radical Pipelines conventions file should be `.claude/rp.md`.
    - The generated file must be human-readable Markdown.
    - The generated file must organize the answers into sections that are easy for future agents to read.
    - The setup must create the parent configuration folder if it does not already exist.
-   - The generated CLI-specific file must contain only the conventions needed by Radical Pipelines for that CLI and must not duplicate general project instructions already present in `AGENTS.md`.
+   - The generated agent tool-specific file must contain only the conventions needed by Radical Pipelines for that tool and must not duplicate general project instructions already present in `AGENTS.md`.
 
 4. **Preserve the repository conventions pointer pattern**
    - The setup must treat project-root `AGENTS.md` as the canonical location for shared, cross-agent project instructions.
    - The setup must not expand this repository's `CLAUDE.md` into a full copy of `AGENTS.md`; when `CLAUDE.md` is used as a pointer file, it must preserve the thin pointer pattern (`@AGENTS.md`).
-   - The setup must not write Radical Pipelines CLI-specific setup details into `CLAUDE.md` when `.claude/rp.md` is the appropriate destination.
+   - The setup must not write Radical Pipelines agent tool-specific setup details into `CLAUDE.md` when `.claude/rp.md` is the appropriate destination.
    - If `CLAUDE.md` is missing in a project and the user wants Claude Code to load shared project instructions, the setup may suggest creating a thin pointer to `AGENTS.md` rather than duplicating the shared content.
-   - If `AGENTS.md` is missing and shared instructions are required, the setup must ask before creating it and must clearly separate that shared file from CLI-specific `rp.md` files.
+   - If `AGENTS.md` is missing and shared instructions are required, the setup must ask before creating it and must clearly separate that shared file from agent tool-specific `rp.md` files.
 
 5. **Make the generated conventions reusable**
-   - The generated CLI-specific conventions file must contain enough information for future Radical Pipelines runs in that CLI to satisfy the project conventions lookup without asking the same setup questions again.
+   - The generated agent tool-specific conventions file must contain enough information for future Radical Pipelines runs with that tool to satisfy the project conventions lookup without asking the same setup questions again.
    - After writing the file, the skill must instruct the user to review and commit the generated conventions file if it should be shared with the project.
    - If the setup also creates or recommends changes to `AGENTS.md` or a thin pointer `CLAUDE.md`, it must instruct the user to review and commit those files separately as shared agent instructions.
 
@@ -61,8 +61,8 @@ The setup flow must follow the repository's existing conventions workflow instea
 
 7. **Update user-facing documentation**
    - The README must describe the automatic setup behavior at a high level.
-   - The documentation must mention where generated Radical Pipelines conventions files are written for supported CLIs.
-   - The documentation must explain that shared project instructions should live in `AGENTS.md`, while CLI-specific Radical Pipelines conventions should live in `.pi/rp.md`, `.claude/rp.md`, or another active CLI equivalent.
+   - The documentation must mention where generated Radical Pipelines conventions files are written for supported agent tools.
+   - The documentation must explain that shared project instructions should live in `AGENTS.md`, while agent tool-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`.
    - The documentation must mention that `CLAUDE.md` may be a thin pointer to `AGENTS.md` and that setup should not duplicate shared content into it.
 
 ## Acceptance criteria
@@ -73,13 +73,13 @@ The setup flow must follow the repository's existing conventions workflow instea
 - Completing setup in Pi creates or updates `.pi/rp.md` with the collected Pi-specific Radical Pipelines conventions in Markdown.
 - Completing setup in Claude Code creates or updates `.claude/rp.md` with the collected Claude-specific Radical Pipelines conventions in Markdown.
 - The generated `rp.md` file does not copy general project guidance already present in `AGENTS.md`.
-- If shared project instructions are missing, the setup directs the user to `AGENTS.md` rather than putting shared guidance in CLI-specific files.
+- If shared project instructions are missing, the setup directs the user to `AGENTS.md` rather than putting shared guidance in agent tool-specific files.
 - If `CLAUDE.md` is a thin pointer to `AGENTS.md`, setup preserves that pointer and does not replace it with duplicated content.
 - If the target conventions file already exists, the setup asks before overwriting it.
 - If `AGENTS.md` or `CLAUDE.md` would be created or changed, the setup asks for explicit confirmation first.
 - After setup completes, a subsequent Radical Pipelines workflow can use the generated conventions file without asking the same questions again.
 - If the user cancels or leaves required information unresolved, no misleading complete conventions file is produced and the workflow stops with a clear message.
-- README documentation is updated to describe the setup behavior, generated file locations, and the separation between shared `AGENTS.md` instructions, optional `CLAUDE.md` pointer files, and CLI-specific `rp.md` conventions.
+- README documentation is updated to describe the setup behavior, generated file locations, and the separation between shared `AGENTS.md` instructions, optional `CLAUDE.md` pointer files, and agent tool-specific `rp.md` conventions.
 
 ## Out of scope
 
@@ -90,5 +90,5 @@ The setup flow must follow the repository's existing conventions workflow instea
 - Inferring all project conventions from repository history without user input.
 - Committing the generated conventions file automatically.
 - Changing the canonical list of required project conventions beyond what the current Radical Pipelines skill needs.
-- Replacing `AGENTS.md` with CLI-specific instruction files as the canonical shared project instructions location.
+- Replacing `AGENTS.md` with agent tool-specific instruction files as the canonical shared project instructions location.
 - Expanding this repository's `CLAUDE.md` pointer into a full instructions document.

--- a/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
+++ b/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
@@ -1,0 +1,67 @@
+# Spec: Create setup to populate project conventions
+
+## Overview
+
+When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write a reusable conventions file. Future pipeline runs in the same project should be able to read that file and proceed without repeating setup.
+
+## Requirements
+
+1. **Detect missing project conventions**
+   - When the Radical Pipelines skill is loaded for a pipeline workflow, it must try to find project-specific conventions using the existing documented lookup order.
+   - If all required conventions are available, the workflow must continue unchanged.
+   - If one or more required conventions are missing, the skill must not proceed with the pipeline until the missing information is supplied or the user cancels.
+
+2. **Offer an interactive setup flow**
+   - When conventions are missing, the skill must explain that Radical Pipelines requires project conventions before it can run.
+   - The setup must ask the user for the required convention information through a clear sequence of questions.
+   - The setup must allow the user to provide enough information to cover the conventions needed by the skill, including:
+     - where tasks are tracked and how agents should access them;
+     - the pipeline slug format;
+     - worktree usage and commands, if applicable;
+     - branch naming conventions;
+     - pipeline artifact folder location;
+     - how to spawn teams or agents;
+     - commit message conventions.
+
+3. **Create a conventions file**
+   - After collecting answers, the setup must create a conventions file in the current project's CLI-specific configuration folder when appropriate for the active agent CLI.
+   - For Pi, the generated file should be `.pi/rp.md`.
+   - For Claude Code, the generated file should be `.claude/rp.md`.
+   - The generated file must be human-readable Markdown.
+   - The generated file must organize the answers into sections that are easy for future agents to read.
+   - The setup must create the parent configuration folder if it does not already exist.
+
+4. **Make the generated conventions reusable**
+   - The generated file must contain enough information for future Radical Pipelines runs to satisfy the project conventions lookup without asking the same setup questions again.
+   - After writing the file, the skill must instruct the user to review and commit the generated conventions file if it should be shared with the project.
+
+5. **Handle partial or cancelled setup safely**
+   - If the user declines setup or does not provide required answers, the skill must stop and explain what is still missing.
+   - The setup must not create an incomplete conventions file unless it clearly marks unresolved items and tells the user the setup is incomplete.
+   - The setup must not overwrite an existing conventions file without explicit user confirmation.
+
+6. **Update user-facing documentation**
+   - The README must describe the automatic setup behavior at a high level.
+   - The documentation must mention where generated conventions files are written for supported CLIs.
+
+## Acceptance criteria
+
+- Starting a Radical Pipelines workflow in a project with complete conventions continues without triggering setup.
+- Starting a workflow in a project with no discoverable conventions prompts the user to run the setup flow instead of failing silently or proceeding with assumptions.
+- The setup flow asks for all conventions required by the skill to run a pipeline.
+- Completing setup in Pi creates `.pi/rp.md` with the collected conventions in Markdown.
+- Completing setup in Claude Code creates `.claude/rp.md` with the collected conventions in Markdown.
+- If the target conventions file already exists, the setup asks before overwriting it.
+- After setup completes, a subsequent Radical Pipelines workflow can use the generated conventions file without asking the same questions again.
+- If the user cancels or leaves required information unresolved, no misleading complete conventions file is produced and the workflow stops with a clear message.
+- README documentation is updated to describe the setup behavior and generated file locations.
+
+## Out of scope
+
+- Building a graphical or TUI setup wizard.
+- Supporting non-Markdown convention file formats.
+- Adding support for pipeline phases beyond the currently supported phase 1 workflow.
+- Automatically creating or configuring external task trackers, repositories, worktrees, branches, or teams.
+- Inferring all project conventions from repository history without user input.
+- Committing the generated conventions file automatically.
+- Changing the canonical list of required project conventions beyond what the current Radical Pipelines skill needs.

--- a/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
+++ b/.pipelines/9-create-setup-to-populate-project-conventions/spec.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write reusable convention guidance in the correct place for the active agent tool. Future pipeline runs in the same project should be able to read the generated guidance and proceed without repeating setup.
+When a user starts a Radical Pipelines workflow in a project where project conventions cannot be found, the skill should guide the user through a setup flow, collect the missing convention information, and write reusable convention guidance in the correct place for the active CLI. Future pipeline runs in the same project should be able to read the generated guidance and proceed without repeating setup.
 
-The setup flow must follow the repository's existing conventions workflow instead of introducing a competing pattern. Shared, cross-agent project instructions belong in the project-root `AGENTS.md`. In this repository, `CLAUDE.md` is intentionally only a thin pointer to `AGENTS.md` (`@AGENTS.md`) and must stay that way. Radical Pipelines agent tool-specific conventions belong in the active tool's `rp.md` file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+The setup flow must follow the repository's existing conventions workflow instead of introducing a competing pattern. Shared, cross-agent project instructions belong in the project-root `AGENTS.md`. In this repository, `CLAUDE.md` is intentionally only a thin pointer to `AGENTS.md` (`@AGENTS.md`) and must stay that way. Radical Pipelines CLI-specific conventions belong in the active CLI's `rp.md` file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
 ## Requirements
 
@@ -12,10 +12,10 @@ The setup flow must follow the repository's existing conventions workflow instea
    - When the Radical Pipelines skill is loaded for a pipeline workflow, it must try to find project-specific conventions using the existing documented lookup order:
      1. project-root `AGENTS.md` for shared project instructions;
      2. a dedicated skill, when one is available;
-     3. the active agent tool's `rp.md` conventions file, such as `.pi/rp.md` or `.claude/rp.md`.
+     3. the active CLI's `rp.md` conventions file, such as `.pi/rp.md` or `.claude/rp.md`.
    - If all required conventions are available, the workflow must continue unchanged.
    - If one or more required conventions are missing, the skill must not proceed with the pipeline until the missing information is supplied or the user cancels.
-   - Detection must distinguish shared cross-agent instructions from Radical Pipelines agent tool-specific conventions, so missing tool-specific data does not cause the setup to duplicate shared `AGENTS.md` content.
+   - Detection must distinguish shared cross-agent instructions from Radical Pipelines CLI-specific conventions, so missing CLI-specific data does not cause the setup to duplicate shared `AGENTS.md` content.
 
 2. **Offer an interactive setup flow**
    - When conventions are missing, the skill must explain that Radical Pipelines requires project conventions before it can run.
@@ -28,27 +28,27 @@ The setup flow must follow the repository's existing conventions workflow instea
      - pipeline artifact folder location;
      - how to spawn teams or agents;
      - commit message conventions.
-   - The setup must identify which answers are shared project instructions and which are agent tool-specific Radical Pipelines conventions.
-   - If the user provides shared cross-agent guidance, the setup must recommend adding or updating project-root `AGENTS.md` rather than copying that guidance into agent tool-specific conventions files.
+   - The setup must identify which answers are shared project instructions and which are CLI-specific Radical Pipelines conventions.
+   - If the user provides shared cross-agent guidance, the setup must recommend adding or updating project-root `AGENTS.md` rather than copying that guidance into CLI-specific conventions files.
 
 3. **Create or update the correct conventions file**
-   - After collecting answers, the setup must create a conventions file in the current project's agent tool-specific configuration folder when appropriate for the active agent tool.
+   - After collecting answers, the setup must create a conventions file in the current project's CLI-specific configuration folder when appropriate for the active CLI.
    - For Pi, the generated Radical Pipelines conventions file should be `.pi/rp.md`.
    - For Claude Code, the generated Radical Pipelines conventions file should be `.claude/rp.md`.
    - The generated file must be human-readable Markdown.
    - The generated file must organize the answers into sections that are easy for future agents to read.
    - The setup must create the parent configuration folder if it does not already exist.
-   - The generated agent tool-specific file must contain only the conventions needed by Radical Pipelines for that tool and must not duplicate general project instructions already present in `AGENTS.md`.
+   - The generated CLI-specific file must contain only the conventions needed by Radical Pipelines for that CLI and must not duplicate general project instructions already present in `AGENTS.md`.
 
 4. **Preserve the repository conventions pointer pattern**
    - The setup must treat project-root `AGENTS.md` as the canonical location for shared, cross-agent project instructions.
    - The setup must not expand this repository's `CLAUDE.md` into a full copy of `AGENTS.md`; when `CLAUDE.md` is used as a pointer file, it must preserve the thin pointer pattern (`@AGENTS.md`).
-   - The setup must not write Radical Pipelines agent tool-specific setup details into `CLAUDE.md` when `.claude/rp.md` is the appropriate destination.
+   - The setup must not write Radical Pipelines CLI-specific setup details into `CLAUDE.md` when `.claude/rp.md` is the appropriate destination.
    - If `CLAUDE.md` is missing in a project and the user wants Claude Code to load shared project instructions, the setup may suggest creating a thin pointer to `AGENTS.md` rather than duplicating the shared content.
-   - If `AGENTS.md` is missing and shared instructions are required, the setup must ask before creating it and must clearly separate that shared file from agent tool-specific `rp.md` files.
+   - If `AGENTS.md` is missing and shared instructions are required, the setup must ask before creating it and must clearly separate that shared file from CLI-specific `rp.md` files.
 
 5. **Make the generated conventions reusable**
-   - The generated agent tool-specific conventions file must contain enough information for future Radical Pipelines runs with that tool to satisfy the project conventions lookup without asking the same setup questions again.
+   - The generated CLI-specific conventions file must contain enough information for future Radical Pipelines runs with that CLI to satisfy the project conventions lookup without asking the same setup questions again.
    - After writing the file, the skill must instruct the user to review and commit the generated conventions file if it should be shared with the project.
    - If the setup also creates or recommends changes to `AGENTS.md` or a thin pointer `CLAUDE.md`, it must instruct the user to review and commit those files separately as shared agent instructions.
 
@@ -61,8 +61,8 @@ The setup flow must follow the repository's existing conventions workflow instea
 
 7. **Update user-facing documentation**
    - The README must describe the automatic setup behavior at a high level.
-   - The documentation must mention where generated Radical Pipelines conventions files are written for supported agent tools.
-   - The documentation must explain that shared project instructions should live in `AGENTS.md`, while agent tool-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`.
+   - The documentation must mention where generated Radical Pipelines conventions files are written for supported CLIs.
+   - The documentation must explain that shared project instructions should live in `AGENTS.md`, while CLI-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`.
    - The documentation must mention that `CLAUDE.md` may be a thin pointer to `AGENTS.md` and that setup should not duplicate shared content into it.
 
 ## Acceptance criteria
@@ -73,13 +73,13 @@ The setup flow must follow the repository's existing conventions workflow instea
 - Completing setup in Pi creates or updates `.pi/rp.md` with the collected Pi-specific Radical Pipelines conventions in Markdown.
 - Completing setup in Claude Code creates or updates `.claude/rp.md` with the collected Claude-specific Radical Pipelines conventions in Markdown.
 - The generated `rp.md` file does not copy general project guidance already present in `AGENTS.md`.
-- If shared project instructions are missing, the setup directs the user to `AGENTS.md` rather than putting shared guidance in agent tool-specific files.
+- If shared project instructions are missing, the setup directs the user to `AGENTS.md` rather than putting shared guidance in CLI-specific files.
 - If `CLAUDE.md` is a thin pointer to `AGENTS.md`, setup preserves that pointer and does not replace it with duplicated content.
 - If the target conventions file already exists, the setup asks before overwriting it.
 - If `AGENTS.md` or `CLAUDE.md` would be created or changed, the setup asks for explicit confirmation first.
 - After setup completes, a subsequent Radical Pipelines workflow can use the generated conventions file without asking the same questions again.
 - If the user cancels or leaves required information unresolved, no misleading complete conventions file is produced and the workflow stops with a clear message.
-- README documentation is updated to describe the setup behavior, generated file locations, and the separation between shared `AGENTS.md` instructions, optional `CLAUDE.md` pointer files, and agent tool-specific `rp.md` conventions.
+- README documentation is updated to describe the setup behavior, generated file locations, and the separation between shared `AGENTS.md` instructions, optional `CLAUDE.md` pointer files, and CLI-specific `rp.md` conventions.
 
 ## Out of scope
 
@@ -90,5 +90,5 @@ The setup flow must follow the repository's existing conventions workflow instea
 - Inferring all project conventions from repository history without user input.
 - Committing the generated conventions file automatically.
 - Changing the canonical list of required project conventions beyond what the current Radical Pipelines skill needs.
-- Replacing `AGENTS.md` with agent tool-specific instruction files as the canonical shared project instructions location.
+- Replacing `AGENTS.md` with CLI-specific instruction files as the canonical shared project instructions location.
 - Expanding this repository's `CLAUDE.md` pointer into a full instructions document.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The repository ships an [agent skill](https://agentskills.io) that captures the 
 
 ## Install
 
-Install it with the [Skills CLI](https://github.com/vercel-labs/skills):
+Install it with the [Skills command-line tool](https://github.com/vercel-labs/skills):
 
 ```bash
 npx skills add Automattic/radical-pipelines
@@ -75,17 +75,17 @@ The skill is generic — each project defines its own conventions for things lik
 
 1. Shared project instructions in the project-root `AGENTS.md`.
 2. A dedicated conventions skill (e.g., `rp-conventions`).
-3. A Radical Pipelines `rp.md` file in the active CLI's config folder — `.pi/rp.md` for Pi, `.claude/rp.md` for Claude Code, or another active CLI equivalent.
+3. A Radical Pipelines `rp.md` file for the active agent tool — `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are CLI-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active CLI after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
+If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are agent tool-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active agent tool after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
 
-Shared cross-agent project instructions should live in `AGENTS.md`. CLI-specific Radical Pipelines conventions should live in `.pi/rp.md`, `.claude/rp.md`, or the equivalent file for the active CLI. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
+Shared cross-agent project instructions should live in `AGENTS.md`. Agent tool-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
 
 See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples.
 
 ## Current status
 
-CLIs:
+Supported agent tools:
 
 - Claude Code
 - Pi

--- a/README.md
+++ b/README.md
@@ -71,11 +71,15 @@ npx skills add Automattic/radical-pipelines
 
 ## Configuration
 
-The skill is generic — each project defines its own conventions for things like the task source, pipeline slug format, worktree commands, branch naming, artifact folder location, and how teams of agents are spawned. These conventions can live in any of these places (checked in order):
+The skill is generic — each project defines its own conventions for things like the task source, pipeline slug format, worktree commands, branch naming, artifact folder location, and how teams of agents are spawned. The skill looks for those conventions in this order:
 
-1. The `AGENTS.md` file at the project root.
-2. A dedicated skill (e.g., `rp-conventions`).
-3. An `rp.md` file in the CLI's config folder — `.claude/rp.md`, `.pi/rp.md`, etc.
+1. Shared project instructions in the project-root `AGENTS.md`.
+2. A dedicated conventions skill (e.g., `rp-conventions`).
+3. A Radical Pipelines `rp.md` file in the active CLI's config folder — `.pi/rp.md` for Pi, `.claude/rp.md` for Claude Code, or another active CLI equivalent.
+
+If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are CLI-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active CLI after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
+
+Shared cross-agent project instructions should live in `AGENTS.md`. CLI-specific Radical Pipelines conventions should live in `.pi/rp.md`, `.claude/rp.md`, or the equivalent file for the active CLI. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
 
 See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The repository ships an [agent skill](https://agentskills.io) that captures the 
 
 ## Install
 
-Install it with the Skills command-line tool:
+Install it with the [Skills command-line tool](https://github.com/vercel-labs/skills):
 
 ```bash
 npx skills add Automattic/radical-pipelines

--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ The skill is generic — each project defines its own conventions for things lik
 
 1. Shared project instructions in the project-root `AGENTS.md`.
 2. A dedicated conventions skill (e.g., `rp-conventions`).
-3. A Radical Pipelines `rp.md` file for the active agent tool — `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+3. A Radical Pipelines `rp.md` file in the active CLI's config folder — `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are agent tool-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active agent tool after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
+If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are CLI-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active CLI after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
 
-Shared cross-agent project instructions should live in `AGENTS.md`. Agent tool-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
+Shared cross-agent project instructions should live in `AGENTS.md`. CLI-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
 
 See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples.
 
 ## Current status
 
-Supported agent tools:
+CLIs:
 
 - Claude Code
 - Pi

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The repository ships an [agent skill](https://agentskills.io) that captures the 
 
 ## Install
 
-Install it with the [Skills command-line tool](https://github.com/vercel-labs/skills):
+Install it with the Skills command-line tool:
 
 ```bash
 npx skills add Automattic/radical-pipelines


### PR DESCRIPTION
## Summary
- Add missing-conventions detection and setup workflow guidance to the Radical Pipelines skill
- Add a setup reference covering AGENTS.md, CLAUDE.md pointer preservation, and CLI-specific rp.md files
- Update starting pipeline docs and README with setup behavior

## Checks
- git diff --check
- reviewer approved implementation

Closes #9