### PR TITLE
Warn before orchestrating issues with existing PRs

### DIFF
--- a/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
@@ -8,24 +8,32 @@ Before executing these steps, make sure you have loaded the project conventions 
 
 Find the task that this pipeline will work on using the project's **Tasks** convention.
 
-### 2. Determine the pipeline slug
+### 2. Check for existing work
+
+Before creating any worktree, artifacts, or commits, check whether the task already has associated implementation work using the project's **Tasks** convention.
+
+If associated work exists, warn the owner and pause for explicit confirmation before continuing. Include enough detail for the owner to identify the existing work, such as title, state, URL, and owner when available.
+
+If the owner does not explicitly confirm, stop the workflow.
+
+### 3. Determine the pipeline slug
 
 Generate the pipeline slug following the **Pipeline slugs** convention.
 
-### 3. Create and enter the worktree
+### 4. Create and enter the worktree
 
 Create and enter the worktree following the **Worktrees** convention. The corresponding branch is created as described in the **Branch names** convention.
 
 From this point on, all work happens inside the worktree — never modify files in the main working directory.
 
-### 4. Create the pipeline artifacts folder
+### 5. Create the pipeline artifacts folder
 
 Create the folder following the **Pipeline artifact folders** convention.
 
-### 5. Generate the initial prompt
+### 6. Generate the initial prompt
 
 Write the phase-0 prompt to `<artifacts-folder>/prompt.md`. Adapt the task content as a prompt directed at the agents that will run subsequent phases — describe what to do, not how.
 
-### 6. Commit
+### 7. Commit
 
 Commit the artifacts folder following the **Commits** convention.

--- a/.claude/rp.md
+++ b/.claude/rp.md
@@ -4,6 +4,8 @@ All the tasks are issues stored in this repository: https://github.com/Automatti
 
 To manage them, always use the `gh` CLI.
 
+For GitHub issue tasks, associated implementation work means associated pull requests. Before starting a pipeline for an issue, check for associated pull requests with `gh api graphql` by inspecting the issue timeline for `CONNECTED_EVENT` and `CROSS_REFERENCED_EVENT` entries whose subject/source is a pull request. If any are found, warn the owner with the PR number, title, state, URL, and merged status, then stop unless the owner explicitly confirms continuing.
+
 ## Pipeline slugs
 
 Use `<issue-number>-<short-description>` where issue number is the GitHub issue number.

--- a/.pi/rp.md
+++ b/.pi/rp.md
@@ -13,6 +13,8 @@ All the tasks are issues stored in this repository: https://github.com/Automatti
 
 To manage them, always use the `gh` CLI.
 
+For GitHub issue tasks, associated implementation work means associated pull requests. Before starting a pipeline for an issue, check for associated pull requests with `gh api graphql` by inspecting the issue timeline for `CONNECTED_EVENT` and `CROSS_REFERENCED_EVENT` entries whose subject/source is a pull request. If any are found, warn the owner with the PR number, title, state, URL, and merged status, then stop unless the owner explicitly confirms continuing.
+
 ## Pipeline slugs
 
 Use `<issue-number>-<short-description>` where issue number is the GitHub issue number.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npx skills add Automattic/radical-pipelines
 
 ## Configuration
 
-The skill is generic — each project defines its own conventions for things like the task source, pipeline slug format, worktree commands, branch naming, artifact folder location, and how teams of agents are spawned. These conventions can live in any of these places (checked in order):
+The skill is generic — each project defines its own conventions for things like the task source, existing work checks, pipeline slug format, worktree commands, branch naming, artifact folder location, and how teams of agents are spawned. These conventions can live in any of these places (checked in order):
 
 1. The `AGENTS.md` file at the project root.
 2. A dedicated skill (e.g., `rp-conventions`).


### PR DESCRIPTION
## Summary

- Add an explicit existing-PR check to the start-pipeline workflow
- Document the GitHub issue timeline query convention for Pi and Claude
- Update the README configuration overview to mention existing PR checks

Fixes #11

## Testing

- Ran `git diff --check`
