### PR TITLE
Add doc-writer and doc-reviewer agents

### DIFF
--- a/.agents/agents/doc-reviewer.md
+++ b/.agents/agents/doc-reviewer.md
@@ -1,0 +1,9 @@
+---
+name: doc-reviewer
+description: Adversarially review Radical Pipelines documentation updates for accuracy, completeness, and alignment with the implementation
+tools: read, bash
+thinking: high
+---
+You are the Documentation phase reviewer for Radical Pipelines.
+
+Read the prompt, spec, and implementation artifacts in `.pipelines/<pipeline-slug>/`, the project conventions, and the documentation produced by `doc-writer`. Flag claims that do not match the implementation, missing coverage, stale references or examples, violations of the `AGENTS.md` rule that the project `README.md` must be updated when code changes, and unclear or contradictory wording. Return concrete revisions to `doc-writer` and approve only when the documentation is accurate, complete, and consistent with what landed. Do not write the documentation yourself.

--- a/.agents/agents/doc-reviewer.md
+++ b/.agents/agents/doc-reviewer.md
@@ -1,9 +1,9 @@
 ---
 name: doc-reviewer
-description: Adversarially review Radical Pipelines documentation updates for accuracy, completeness, and alignment with the implementation
+description: Adversarially review the host project's documentation updates produced for a Radical Pipelines task for accuracy, completeness, and alignment with the implementation
 tools: read, bash
 thinking: high
 ---
 You are the Documentation phase reviewer for Radical Pipelines.
 
-Read the prompt, spec, and implementation artifacts in `.pipelines/<pipeline-slug>/`, the project conventions, and the documentation produced by `doc-writer`. Flag claims that do not match the implementation, missing coverage, stale references or examples, violations of the `AGENTS.md` rule that the project `README.md` must be updated when code changes, and unclear or contradictory wording. Return concrete revisions to `doc-writer` and approve only when the documentation is accurate, complete, and consistent with what landed. Do not write the documentation yourself.
+Read the prompt, spec, and implementation artifacts for the current task in `.pipelines/<pipeline-slug>/`, the host project's conventions, and the documentation produced by `doc-writer`. Flag claims that do not match the implementation, missing coverage, stale references or examples, violations of any host-project rule (such as an `AGENTS.md` requirement that the `README.md` be kept up to date when code changes), and unclear or contradictory wording. Return concrete revisions to `doc-writer` and approve only when the documentation is accurate, complete, and consistent with what landed. Do not write the documentation yourself.

--- a/.agents/agents/doc-writer.md
+++ b/.agents/agents/doc-writer.md
@@ -1,9 +1,9 @@
 ---
 name: doc-writer
-description: Produce Radical Pipelines documentation updates that reflect what landed in the implementation
+description: Update the host project's documentation to reflect what landed in the implementation phase of a Radical Pipelines task
 tools: read, write, edit, bash
 thinking: medium
 ---
 You are the Documentation phase agent for Radical Pipelines.
 
-Read the prompt, spec, and implementation artifacts in `.pipelines/<pipeline-slug>/` and the project conventions. Update the project `README.md`, package docs, examples, and other internal and external documentation so they reflect what landed. `AGENTS.md` is binding: whenever the implementation changed code, the project `README.md` must be kept up to date. Do not implement code or change behavior.
+Read the prompt, spec, and implementation artifacts for the current task in `.pipelines/<pipeline-slug>/` and the host project's conventions. Update the host project's `README.md`, package docs, examples, and other internal and external documentation so they reflect what landed for this task. If the host project's `AGENTS.md` requires the `README.md` to be kept up to date when code changes, that rule is binding. Do not implement code or change behavior.

--- a/.agents/agents/doc-writer.md
+++ b/.agents/agents/doc-writer.md
@@ -1,0 +1,9 @@
+---
+name: doc-writer
+description: Produce Radical Pipelines documentation updates that reflect what landed in the implementation
+tools: read, write, edit, bash
+thinking: medium
+---
+You are the Documentation phase agent for Radical Pipelines.
+
+Read the prompt, spec, and implementation artifacts in `.pipelines/<pipeline-slug>/` and the project conventions. Update the project `README.md`, package docs, examples, and other internal and external documentation so they reflect what landed. `AGENTS.md` is binding: whenever the implementation changed code, the project `README.md` must be kept up to date. Do not implement code or change behavior.

--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -29,12 +29,13 @@ This skill defines two workflows: the **autonomous workflow** (a full pipeline r
 
 ## Phases
 
-| #   | Phase  | Produces                                         |
-| --- | ------ | ------------------------------------------------ |
-| 0   | Prompt | The raw request (input, not something to create) |
-| 1   | Spec   | Requirements, acceptance criteria, out-of-scope  |
+| #   | Phase         | Agent          | Produces                                              |
+| --- | ------------- | -------------- | ----------------------------------------------------- |
+| 0   | Prompt        | prompt-writer  | The raw request (input, not something to create)      |
+| 1   | Spec          | spec-writer    | Requirements, acceptance criteria, out-of-scope       |
+| 5   | Documentation | doc-writer     | Updated README, package docs, examples, conventions   |
 
-_Only phase 1 is implemented. Phases 2–5 (Design doc, Implementation plan, Implementation, Documentation) will follow the same pattern when added._
+_Only phase 1 has a full autonomous and assisted workflow today. The Documentation phase ships a `doc-writer` paired with an adversarial `doc-reviewer` in a revision loop to update docs after work has landed. Phases 2–4 (Design doc, Implementation plan, Implementation) will follow the same pattern when added._
 
 ## Autonomous run plan
 

--- a/.pi-extension/README.md
+++ b/.pi-extension/README.md
@@ -5,7 +5,7 @@ This Pi package installs the Radical Pipelines skill, phase agent profiles, pi-t
 ## What it includes
 
 - Skill: `skills/radical-pipelines/SKILL.md`.
-- Agents: `prompt-writer` and `spec-writer`. Additional phase agents (`designer`, `planner`, `implementer`, `documenter`) will ship when the `radical-pipelines` skill enables those phases.
+- Agents: `prompt-writer`, `spec-writer`, `doc-writer`, and `doc-reviewer`. Additional phase agents (`designer`, `planner`, `implementer`) will ship when the `radical-pipelines` skill enables those phases.
 - Team templates: `radical-pipelines-spec`. The full `radical-pipelines` team will ship alongside the remaining phase agents.
 - Bundled dependency resources loaded through `node_modules/...`: `pi-teams` and `@zenobius/pi-worktrees`.
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ This routes through the root-level Pi manifest (`package.json` at the repo root)
 The package installs:
 
 - the `radical-pipelines` skill;
-- six phase agent profiles: `prompt-writer`, `spec-writer`, `designer`, `planner`, `implementer`, and `documenter`;
-- `radical-pipelines` and `radical-pipelines-spec` pi-teams templates;
+- phase agent profiles for the implemented phases: `prompt-writer`, `spec-writer`, `doc-writer`, and `doc-reviewer`. `designer`, `planner`, and `implementer` will ship as those phases are added;
+- the `radical-pipelines-spec` pi-teams template. The full `radical-pipelines` team will ship alongside the remaining phase agents;
 - bundled `pi-teams` and `@zenobius/pi-worktrees` Pi resources.
 
 During package development in this repository, install dependencies first and then install the local path:
@@ -130,7 +130,7 @@ pi install ./.pi-extension -l
 After installing the Pi package in a repository:
 
 1. Start with `/skill:radical-pipelines` or by asking Pi to run Radical Pipelines.
-2. Use pi-teams predefined team creation with the `radical-pipelines` or `radical-pipelines-spec` templates.
+2. Use pi-teams predefined team creation with the `radical-pipelines-spec` template.
 
 Validation for the local package has verified `npm pack --dry-run`, `pi install ./.pi-extension -l`, `pi list`, `/skill:radical-pipelines`, predefined team discovery, and spawning the `radical-pipelines-spec` team. The local validation used print mode rather than a full manual interactive UI.
 
@@ -185,7 +185,8 @@ Phases (within implemented workflows):
   - `single` — one spec writer + one adversarial reviewer in a revision loop.
   - `multi` — N parallel spec writers followed by a consolidator that merges the drafts.
 - In the assisted workflow, phase 1 produces `requirements.md` and `spec.md` through Q&A with the owner.
-- Phases 2–5 (Design doc, Implementation plan, Implementation, Documentation) are not yet implemented.
+- **Phase 5 (Documentation)** ships a `doc-writer` paired with an adversarial `doc-reviewer` in a revision loop. They update the README, package docs, examples, and project conventions to match what landed. Full pipeline orchestration into phase 5 will arrive when phases 2–4 are implemented.
+- Phases 2–4 (Design doc, Implementation plan, Implementation) are not yet implemented.
 
 Pi package limitations:
 


### PR DESCRIPTION
## Summary

Closes #21.

- Adds `doc-writer` and adversarial `doc-reviewer` agent profiles under `.agents/agents/` (single source of truth shared by the Pi extension and Claude Code plugin via existing symlinks).
- `doc-writer` follows the sibling writer convention (`prompt-writer`, `spec-writer`): short frontmatter + one paragraph that says what to read, what to produce, and what not to do. It also enforces the binding `AGENTS.md` rule that the project `README.md` must be updated whenever code changes.
- `doc-reviewer` mirrors the same convention from the reviewer side: read artifacts and the writer's output, flag mismatches with the implementation, missing coverage, stale references, `AGENTS.md` violations, and unclear wording — without writing the docs itself.
- Updates the SKILL phase table to add row 5 (Documentation) and an `Agent` column, plus a note that doc-writer + doc-reviewer run as an adversarial revision loop while phases 2–4 are still pending.
- Updates the root `README.md` and `.pi-extension/README.md` to list the new agents and remove the outdated `documenter` placeholder.

No changes to `teams.yaml`: the documentation phase is invoked directly without a dedicated team.

## Test plan

- [ ] Verify both new agent files load correctly via `pi list` after `pi install ./.pi-extension -l`.
- [ ] Verify `doc-writer` and `doc-reviewer` appear in the agent profiles bundled with the Claude Code plugin (root `agents/` symlink → `.agents/agents/`).
- [ ] Confirm the SKILL phase table renders cleanly (column alignment).
- [ ] Spot-check that no leftover references to `documenter`, `radical-pipelines-doc`, or `doc-witter` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)