### PR TITLE
Define Pi agent setup flow

### DIFF
--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -61,6 +61,7 @@ This skill is generic, but each project has its own conventions that you must fo
 - Branch names
 - Pipeline artifact folders
 - Spawning teams of agents
+- Pi agent definitions, when the active CLI is Pi
 - Commits
 
 This information is necessary to execute the pipelines correctly, so you must load and verify it before starting any workflow.
@@ -75,9 +76,20 @@ To find the project-specific conventions, try the following in order:
 
 When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. CLI-specific Radical Pipelines details belong in the active CLI's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
 
+### Pi agent definitions
+
+When the active CLI is Pi, verify phase agent definitions before starting a pipeline or spawning a predefined team. Check repository-local Pi agents first, then user-local/global Pi agents:
+
+1. Repository-local: `.pi/agents/<agent-name>.md` or `.pi/agents/<agent-name>/SKILL.md` in the target repository.
+2. User-local/global: `~/.pi/agent/agents/<agent-name>.md` or `~/.pi/agent/agents/<agent-name>/SKILL.md`.
+
+The required agent set is the set needed by the target phase and selected execution mode. For example, single-agent phase 1 needs `spec-writer` and `spec-reviewer`; design, plan, implementation, and documentation phases need their writer/reviewer pair.
+
+If neither repository-local nor user-local/global definitions are available for the required agents, stop before running the pipeline. Ask the owner which Radical Pipelines agents they want to copy/paste and install, and whether to install them in the repository-local `.pi/agents/` directory or the user-local/global `~/.pi/agent/agents/` directory. Do not create or copy agent files without explicit confirmation.
+
 ### Passing conventions to phase agents
 
-You are responsible for loading and verifying project conventions before launching phase agents. Phase agents should not repeat the full convention-discovery flow or infer project paths from generic examples.
+You are responsible for loading and verifying project conventions and, for Pi, required agent definitions before launching phase agents. Phase agents should not repeat the full convention-discovery flow or infer paths from generic examples.
 
 When spawning a phase agent or team, include the resolved role-specific context in the initial prompt:
 

--- a/.agents/skills/radical-pipelines/SKILL.md
+++ b/.agents/skills/radical-pipelines/SKILL.md
@@ -74,7 +74,7 @@ To find the project-specific conventions, try the following in order:
 2. A dedicated conventions skill called `rp-conventions` or similar, when one is available.
 3. The Radical Pipelines `rp.md` file in the active CLI's project configuration folder, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. CLI-specific Radical Pipelines details belong in the active CLI's `rp.md` file and must not be copied into `CLAUDE.md` or duplicated from `AGENTS.md`.
+When reading conventions, distinguish shared cross-agent project instructions from CLI-specific Radical Pipelines conventions. `AGENTS.md` is the canonical home for shared guidance. Claude Code-specific Radical Pipelines details belong only in `.claude/rp.md`; Pi-specific Radical Pipelines details belong only in `.pi/rp.md`. Do not copy CLI-specific conventions into `CLAUDE.md`, do not duplicate shared `AGENTS.md` content into CLI files, and do not mix Claude Code conventions into Pi files or Pi conventions into Claude Code files.
 
 ### Pi agent definitions
 

--- a/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
+++ b/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
@@ -48,18 +48,37 @@ If only some required agents are missing, ask whether to copy/paste and install 
 
 ## 5. Collect required conventions
 
-Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or CLI-specific Radical Pipelines guidance for the active `rp.md` file.
+Ask for the required information in a clear sequence, but keep shared project conventions separate from CLI-specific conventions.
+
+### Shared project conventions
+
+Shared conventions describe the project regardless of which agent CLI runs the pipeline. Prefer `AGENTS.md` for reusable shared guidance, or include only the Radical Pipelines-specific subset in each CLI's `rp.md` when the owner does not want shared files changed.
 
 1. **Tasks:** Where tasks are tracked and how agents should access them.
 2. **Pipeline slugs:** The slug format to use for pipeline names.
-3. **Worktrees:** Whether worktrees are used and the exact commands or workflow for creating, entering, and removing them.
-4. **Branch names:** How branch names are chosen or created.
-5. **Pipeline artifact folders:** Where pipeline artifacts are stored.
-6. **Spawning teams of agents:** How the active CLI should spawn teams or agents.
-7. **Commits:** Commit message format and any other commit rules.
-8. **Pi agent setup, for Pi only:** The required agents, where they were found or installed, and whether future runs should prefer repository-local `.pi/agents/` definitions or user-local/global `~/.pi/agent/agents/` definitions when both exist.
+3. **Pipeline artifact folders:** Where pipeline artifacts are stored.
+4. **Commits:** Commit message format and any other commit rules.
 
-If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into CLI-specific conventions files.
+### Claude Code conventions
+
+Collect these only when the active CLI is Claude Code, and write them only to `.claude/rp.md`:
+
+1. **Claude Code worktrees:** The exact Claude Code command or tool flow for creating, entering, exiting, and removing worktrees.
+2. **Claude Code branch names:** How Claude Code chooses or creates branch names.
+3. **Claude Code team spawning:** The exact Claude Code command, tool, or plugin used to spawn teams or agents.
+4. **Claude Code prerequisites:** Any Claude Code plugin, marketplace, hook, or command setup required before running Radical Pipelines.
+
+### Pi conventions
+
+Collect these only when the active CLI is Pi, and write them only to `.pi/rp.md`:
+
+1. **Pi prerequisites:** Required Pi packages, plugins, or one-time setup commands.
+2. **Pi worktrees:** The exact Pi command or tool flow for creating, entering, and removing worktrees.
+3. **Pi branch names:** How Pi chooses or creates branch names.
+4. **Pi team spawning:** The exact Pi tool or `pi-teams` workflow used to spawn teams or agents.
+5. **Pi agent setup:** The required agents, where they were found or installed, and whether future runs should prefer repository-local `.pi/agents/` definitions or user-local/global `~/.pi/agent/agents/` definitions when both exist.
+
+If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into CLI-specific conventions files. Never write Claude Code conventions into `.pi/rp.md`, and never write Pi conventions into `.claude/rp.md`.
 
 ## 6. Confirm writes before changing files
 
@@ -73,7 +92,9 @@ If any required answer is missing, do not create a misleading complete conventio
 
 ## 7. Write human-readable Markdown
 
-Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Use clear sections such as:
+Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Do not include sections for inactive CLIs.
+
+For Claude Code, use clear sections such as:
 
 ```markdown
 ## Managing tasks
@@ -84,11 +105,11 @@ Write the active CLI `rp.md` file with only Radical Pipelines conventions needed
 
 ...
 
-## Worktrees
+## Claude Code worktrees
 
 ...
 
-## Branch names
+## Claude Code branch names
 
 ...
 
@@ -96,20 +117,56 @@ Write the active CLI `rp.md` file with only Radical Pipelines conventions needed
 
 ...
 
-## Spawning teams of agents
+## Claude Code team spawning
 
 ...
 
 ## Commits
 
 ...
+```
+
+For Pi, use clear sections such as:
+
+```markdown
+## Pi prerequisites
+
+...
+
+## Managing tasks
+
+...
+
+## Pipeline slugs
+
+...
+
+## Pi worktrees
+
+...
+
+## Pi branch names
+
+...
+
+## Pipeline artifact folders
+
+...
+
+## Pi team spawning
+
+...
 
 ## Pi agent setup
 
 ...
+
+## Commits
+
+...
 ```
 
-Do not duplicate general project instructions already present in `AGENTS.md`.
+Do not duplicate general project instructions already present in `AGENTS.md`. Never write Claude Code-only sections to `.pi/rp.md`; never write Pi-only sections to `.claude/rp.md`.
 
 ## 8. Finish safely
 

--- a/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
+++ b/.agents/skills/radical-pipelines/reference/setup-project-conventions.md
@@ -11,8 +11,9 @@ Do not continue the pipeline. Tell the owner:
 - Which required conventions are still missing.
 - Shared cross-agent project instructions belong in project-root `AGENTS.md`.
 - CLI-specific Radical Pipelines conventions belong in the active CLI conventions file, such as `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
+- In Pi, phase agent definitions must also be discoverable before a pipeline can launch agents.
 
-Ask whether the owner wants to run setup now. If they decline or cancel, stop and summarize the missing conventions.
+Ask whether the owner wants to run setup now. If they decline or cancel, stop and summarize the missing conventions or missing Pi agents.
 
 ## 2. Identify the active CLI target
 
@@ -33,7 +34,19 @@ If `CLAUDE.md` exists and is a thin pointer such as `@AGENTS.md`, preserve that 
 
 If `AGENTS.md` is missing and shared cross-agent instructions are needed, ask whether to create it. Do not create, overwrite, or replace `AGENTS.md` or `CLAUDE.md` without explicit confirmation.
 
-## 4. Collect required conventions
+## 4. Check Pi agent definitions
+
+When the active CLI is Pi, check for the agent definitions required by the target phase and selected execution mode before collecting or writing conventions:
+
+1. Check repository-local Pi agents first: `.pi/agents/<agent-name>.md` or `.pi/agents/<agent-name>/SKILL.md`.
+2. If any required agent is not found in the repository, check user-local/global Pi agents: `~/.pi/agent/agents/<agent-name>.md` or `~/.pi/agent/agents/<agent-name>/SKILL.md`.
+3. Report which required agents were found in the repository, which were found globally, and which are missing.
+
+If all required agents are present across those locations, continue setup. If no required agents are available in either location, stop and ask the owner which Radical Pipelines agents they want to copy/paste and install. Ask whether to install them repository-locally under `.pi/agents/` or user-locally/globally under `~/.pi/agent/agents/`. Do not create or copy agent files without explicit confirmation.
+
+If only some required agents are missing, ask whether to copy/paste and install the missing agents, again confirming the destination before writing. After installation, tell the owner to verify discovery with the Pi/pi-teams predefined-agent listing for the target project.
+
+## 5. Collect required conventions
 
 Ask for the following information in a clear sequence. For each answer, identify whether it is shared project guidance for `AGENTS.md` or CLI-specific Radical Pipelines guidance for the active `rp.md` file.
 
@@ -44,10 +57,11 @@ Ask for the following information in a clear sequence. For each answer, identify
 5. **Pipeline artifact folders:** Where pipeline artifacts are stored.
 6. **Spawning teams of agents:** How the active CLI should spawn teams or agents.
 7. **Commits:** Commit message format and any other commit rules.
+8. **Pi agent setup, for Pi only:** The required agents, where they were found or installed, and whether future runs should prefer repository-local `.pi/agents/` definitions or user-local/global `~/.pi/agent/agents/` definitions when both exist.
 
 If the owner provides general project guidance, recommend adding or updating `AGENTS.md` instead of copying that guidance into CLI-specific conventions files.
 
-## 5. Confirm writes before changing files
+## 6. Confirm writes before changing files
 
 Before writing anything, summarize the proposed file changes and ask for explicit confirmation.
 
@@ -57,7 +71,7 @@ Before writing anything, summarize the proposed file changes and ask for explici
 
 If any required answer is missing, do not create a misleading complete conventions file. Either stop and explain what is unresolved, or, only if the owner explicitly asks for a draft, write a file that clearly marks unresolved items and state that setup is incomplete.
 
-## 6. Write human-readable Markdown
+## 7. Write human-readable Markdown
 
 Write the active CLI `rp.md` file with only Radical Pipelines conventions needed by that CLI. Use clear sections such as:
 
@@ -89,11 +103,15 @@ Write the active CLI `rp.md` file with only Radical Pipelines conventions needed
 ## Commits
 
 ...
+
+## Pi agent setup
+
+...
 ```
 
 Do not duplicate general project instructions already present in `AGENTS.md`.
 
-## 7. Finish safely
+## 8. Finish safely
 
 After setup completes, tell the owner:
 

--- a/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/starting-a-pipeline.md
@@ -2,7 +2,7 @@
 
 Sets up a pipeline through phase 0 — identifies the task, creates the worktree and artifacts folder, writes `prompt.md`, and commits. Both the autonomous workflow and the assisted workflow use this as their entry point or fallback.
 
-Before executing these steps, make sure you have loaded and verified the project conventions (see `SKILL.md` → "Project conventions"). If any required convention is missing, stop and run the setup flow in `setup-project-conventions.md` before continuing. Each step below applies one of those conventions.
+Before executing these steps, make sure you have loaded and verified the project conventions (see `SKILL.md` → "Project conventions"). If the active CLI is Pi, also verify the required phase agent definitions by checking repository-local `.pi/agents/` first and user-local/global `~/.pi/agent/agents/` second. If any required convention or Pi agent definition is missing, stop and run the setup flow in `setup-project-conventions.md` before continuing. Each step below applies one of those conventions.
 
 ## Steps
 

--- a/.claude/rp.md
+++ b/.claude/rp.md
@@ -10,13 +10,13 @@ For GitHub issue tasks, associated implementation work means associated pull req
 
 Use `<issue-number>-<short-description>` where issue number is the GitHub issue number.
 
-## Worktrees
+## Claude Code worktrees
 
 Folder: `.claude/worktrees/<pipeline-slug>`
 Enter worktree: `EnterWorktree` with name: `<pipeline-slug>`
 Exit worktree: `ExitWorktree` with name: `<pipeline-slug>`
 
-## Branch names
+## Claude Code branch names
 
 Created automatically by `EnterWorktree`: `worktree-<pipeline-slug>`
 
@@ -24,7 +24,7 @@ Created automatically by `EnterWorktree`: `worktree-<pipeline-slug>`
 
 Use `.pipelines/<pipeline-slug>`.
 
-## Spawning teams of agents
+## Claude Code team spawning
 
 Use `TeamCreate`.
 

--- a/.pi-extension/README.md
+++ b/.pi-extension/README.md
@@ -56,9 +56,10 @@ Verified local results:
 1. Install the package globally or project-locally.
 2. Start the workflow with `/skill:radical-pipelines` or by asking Pi to run Radical Pipelines.
 3. Ensure the packaged team templates have been registered in the global `~/.pi/teams.yaml` file used by `pi-teams`.
-4. Use pi-teams predefined team creation with the `radical-pipelines-spec`, `radical-pipelines-design`, `radical-pipelines-plan`, or `radical-pipelines-implementation` template, depending on the phase you are running.
+4. Ensure the required phase agent definitions are discoverable. Check repository-local `.pi/agents/` first, then user-local/global `~/.pi/agent/agents/`.
+5. Use pi-teams predefined team creation with the `radical-pipelines-spec`, `radical-pipelines-design`, `radical-pipelines-plan`, or `radical-pipelines-implementation` template, depending on the phase you are running.
 
-The target project still needs Radical Pipelines conventions, typically in `AGENTS.md`, a CLI-specific `.pi/rp.md`, or a dedicated conventions skill. Those conventions should define task lookup, pipeline slug format, pipeline artifact folders (for example `.pipelines/<pipeline-slug>`), `/worktree` setup, branch naming, team spawning, and commit format. Reviewer agents write inspectable `spec-review-N.md`, `design-doc-review-N.md`, `plan-review-N.md`, `code-review-N.md`, and `docs-review-N.md` artifacts into the task's artifact folder.
+The target project still needs Radical Pipelines conventions, typically in `AGENTS.md`, a CLI-specific `.pi/rp.md`, or a dedicated conventions skill. Those conventions should define task lookup, pipeline slug format, pipeline artifact folders (for example `.pipelines/<pipeline-slug>`), `/worktree` setup, branch naming, team spawning, commit format, and Pi agent setup. During Pi setup, if no required agents are found in repository-local `.pi/agents/` or user-local/global `~/.pi/agent/agents/`, the workflow asks which Radical Pipelines agents to copy/paste and install before it launches teams. Reviewer agents write inspectable `spec-review-N.md`, `design-doc-review-N.md`, `plan-review-N.md`, `code-review-N.md`, and `docs-review-N.md` artifacts into the task's artifact folder.
 
 ## Bundled dependencies
 
@@ -78,7 +79,7 @@ That command does not install Pi extensions, `pi-teams`, `@zenobius/pi-worktrees
 
 ## Limitations
 
-- pi-teams currently discovers predefined agents and team templates from global or project-local locations, not package-local files. Radical Pipelines team definitions should be registered globally in `~/.pi/teams.yaml`, with agent profiles in `~/.pi/agent/agents/`, before predefined Radical Pipelines teams are visible.
+- pi-teams currently discovers predefined agents and team templates from global or project-local locations, not package-local files. Radical Pipelines team definitions should be registered globally in `~/.pi/teams.yaml`; agent profiles should be available either repository-locally in `.pi/agents/` or user-locally/globally in `~/.pi/agent/agents/`, before predefined Radical Pipelines teams are visible.
 - Local validation used Pi print mode, not a full manual interactive UI pass.
 - Local validation on Node v20.14.0 produced npm `EBADENGINE` warnings from transitive dependencies and two moderate `npm audit` findings.
 - Bundled dependency resource paths may need updates if future `pi-teams` or `@zenobius/pi-worktrees` releases move their Pi resources.

--- a/.pi/rp.md
+++ b/.pi/rp.md
@@ -1,4 +1,4 @@
-## Prerequisites
+## Pi prerequisites
 
 This project requires the Radical Pipelines Pi package. It is declared in `.pi/settings.json` and pi installs it automatically on startup. The package bundles `pi-teams` and `@zenobius/pi-worktrees`. If for any reason it is missing, install it manually:
 
@@ -18,7 +18,7 @@ For GitHub issue tasks, associated implementation work means associated pull req
 
 Use `<issue-number>-<short-description>` where issue number is the GitHub issue number.
 
-## Worktrees
+## Pi worktrees
 
 This project uses the `@zenobius/pi-worktrees` plugin. Always use `/worktree` commands — never raw `git worktree` commands.
 
@@ -30,7 +30,7 @@ This project uses the `@zenobius/pi-worktrees` plugin. Always use `/worktree` co
 - **Create:** `/worktree create worktree-<pipeline-slug> --name <pipeline-slug>`
 - **Remove:** `/worktree remove <pipeline-slug>`
 
-## Branch names
+## Pi branch names
 
 Created as `worktree-<pipeline-slug>` (the branch argument passed to `/worktree create`).
 
@@ -38,7 +38,7 @@ Created as `worktree-<pipeline-slug>` (the branch argument passed to `/worktree 
 
 Use `.pipelines/<pipeline-slug>`.
 
-## Spawning teams of agents
+## Pi team spawning
 
 Use `pi-teams`.
 
@@ -54,6 +54,12 @@ If a spawned Pi teammate fails with a provider login or API-key error:
 6. If no authenticated model is available, stop and tell the owner which provider failed and that they need to authenticate a provider or pass an explicit provider-qualified model.
 
 Keep this recovery provider-neutral. Do not hardcode any provider as the fallback default.
+
+## Pi agent setup
+
+Before launching a Pi team, verify the required phase agent definitions are discoverable by checking repository-local `.pi/agents/` first, then user-local/global `~/.pi/agent/agents/`.
+
+For this repository, the canonical phase agent source files live in `.agents/agents/` and are exposed to packages through symlinks. If required agents are missing from both Pi discovery locations, stop and ask the owner which Radical Pipelines agents to copy/paste and install, and whether to install them repository-locally in `.pi/agents/` or user-locally/globally in `~/.pi/agent/agents/`.
 
 ## Commits
 

--- a/README.md
+++ b/README.md
@@ -149,17 +149,19 @@ The skill is generic — each project defines its own conventions for things lik
 2. A dedicated conventions skill (e.g., `rp-conventions`).
 3. A Radical Pipelines `rp.md` file in the active CLI's config folder — `.pi/rp.md` for Pi or `.claude/rp.md` for Claude Code.
 
-If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are CLI-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active CLI after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
+If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, separates shared project guidance from CLI-specific guidance, and can write reusable Markdown for the active CLI after confirmation. Pi setup writes only Pi conventions to `.pi/rp.md`; Claude Code setup writes only Claude Code conventions to `.claude/rp.md`.
+
+Shared project conventions include task tracking, pipeline slug format, pipeline artifact folder location, and commit rules. Claude Code conventions include Claude Code worktree commands, branch creation, team spawning, and Claude Code prerequisites. Pi conventions include Pi packages and plugins, Pi worktree commands, branch creation, pi-teams spawning, provider/model recovery, and Pi agent setup. Do not mix Claude Code conventions into `.pi/rp.md`, and do not mix Pi conventions into `.claude/rp.md`.
 
 For Pi, setup also verifies that the required phase agent definitions are discoverable before the pipeline starts. It checks repository-local agents first (`.pi/agents/<agent>.md` or `.pi/agents/<agent>/SKILL.md`), then user-local/global agents (`~/.pi/agent/agents/<agent>.md` or `~/.pi/agent/agents/<agent>/SKILL.md`). If none of the required agents are available, setup stops and asks which Radical Pipelines agents the user wants to copy/paste and install, and whether to install them repository-locally or user-locally/globally.
 
-Shared cross-agent project instructions should live in `AGENTS.md`. CLI-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
+Shared cross-agent project instructions should live in `AGENTS.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
 
 The orchestrator loads and verifies conventions before launching phase agents. When it spawns a phase agent or team, it passes the resolved pipeline slug, artifact folder path, exact artifact paths for that role, and the role-specific host-project conventions listed in the agent profile. Phase agents report a blocker when required context is missing instead of inferring paths from generic examples.
 
 Reviewer agents write inspectable review artifacts into the task's artifact folder on every review iteration. Current artifact names are `spec-review-N.md`, `design-doc-review-N.md`, `plan-review-N.md`, `code-review-N.md`, and `docs-review-N.md`, where N starts at 1 and increments for each writer/reviewer round.
 
-See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples. Pi projects should define the pipeline artifact folder convention (for example `.pipelines/<pipeline-slug>`), worktree root setup (for example `/worktree settings worktreeRoot .pi/worktrees`), pi-teams spawning conventions, and Pi agent setup expectations.
+See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples of separate CLI convention files. Pi projects should define Pi-only worktree setup (for example `/worktree settings worktreeRoot .pi/worktrees`), pi-teams spawning conventions, and Pi agent setup expectations in `.pi/rp.md`; Claude Code projects should define Claude Code-only worktree and team-spawning conventions in `.claude/rp.md`.
 
 ## Current status and limitations
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,15 @@ The skill is generic — each project defines its own conventions for things lik
 
 If required conventions are missing when a workflow starts, Radical Pipelines stops before running the pipeline and offers an interactive setup flow. Setup asks for the missing convention details, explains which answers are shared project guidance and which are CLI-specific Radical Pipelines guidance, and can write a reusable Markdown conventions file for the active CLI after confirmation. Pi setup writes `.pi/rp.md`; Claude Code setup writes `.claude/rp.md`.
 
+For Pi, setup also verifies that the required phase agent definitions are discoverable before the pipeline starts. It checks repository-local agents first (`.pi/agents/<agent>.md` or `.pi/agents/<agent>/SKILL.md`), then user-local/global agents (`~/.pi/agent/agents/<agent>.md` or `~/.pi/agent/agents/<agent>/SKILL.md`). If none of the required agents are available, setup stops and asks which Radical Pipelines agents the user wants to copy/paste and install, and whether to install them repository-locally or user-locally/globally.
+
 Shared cross-agent project instructions should live in `AGENTS.md`. CLI-specific Radical Pipelines conventions should live in `.pi/rp.md` or `.claude/rp.md`. `CLAUDE.md` may be a thin pointer to `AGENTS.md` (for example, `@AGENTS.md`); setup preserves that pattern and should not duplicate shared `AGENTS.md` content into `CLAUDE.md`.
 
 The orchestrator loads and verifies conventions before launching phase agents. When it spawns a phase agent or team, it passes the resolved pipeline slug, artifact folder path, exact artifact paths for that role, and the role-specific host-project conventions listed in the agent profile. Phase agents report a blocker when required context is missing instead of inferring paths from generic examples.
 
 Reviewer agents write inspectable review artifacts into the task's artifact folder on every review iteration. Current artifact names are `spec-review-N.md`, `design-doc-review-N.md`, `plan-review-N.md`, `code-review-N.md`, and `docs-review-N.md`, where N starts at 1 and increments for each writer/reviewer round.
 
-See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples. Pi projects should define the pipeline artifact folder convention (for example `.pipelines/<pipeline-slug>`), worktree root setup (for example `/worktree settings worktreeRoot .pi/worktrees`), and pi-teams spawning conventions.
+See this repository's own [`.claude/rp.md`](./.claude/rp.md) and [`.pi/rp.md`](./.pi/rp.md) for examples. Pi projects should define the pipeline artifact folder convention (for example `.pipelines/<pipeline-slug>`), worktree root setup (for example `/worktree settings worktreeRoot .pi/worktrees`), pi-teams spawning conventions, and Pi agent setup expectations.
 
 ## Current status and limitations
 
@@ -185,6 +187,6 @@ Phases (within implemented workflows):
 
 Pi package limitations:
 
-- pi-teams currently reads predefined agents/templates from global or project-local locations, not package-local files. Radical Pipelines team definitions should be registered globally in `~/.pi/teams.yaml`, with agent profiles in `~/.pi/agent/agents/`, before predefined Radical Pipelines teams are visible.
+- pi-teams currently reads predefined agents/templates from global or project-local locations, not package-local files. Radical Pipelines team definitions should be registered globally in `~/.pi/teams.yaml`; agent profiles should be available either repository-locally in `.pi/agents/` or user-locally/globally in `~/.pi/agent/agents/`, before predefined Radical Pipelines teams are visible.
 - Local validation on Node v20.14.0 produced npm `EBADENGINE` warnings from transitive dependencies and two moderate `npm audit` findings.
 - Open PRs may change nearby guidance later: PR #6 may improve pi-teams examples, PR #10 may change convention setup, and PR #12 may add orchestration safeguards. This package does not depend on those PRs being merged.


### PR DESCRIPTION
## Summary
- document the Pi setup check for repository-local agents before user-local/global agents
- make missing Pi agents part of the setup blocker flow before launching teams
- update package and project README guidance for new-project Pi agent setup

Fixes #34

## Testing
- 
