### PR TITLE
Sync landing page with current pipeline; drop phantom prompt-writer agent

### DIFF
--- a/.pi-extension/README.md
+++ b/.pi-extension/README.md
@@ -5,7 +5,7 @@ This Pi package ships the Radical Pipelines skill, phase agent profiles, pi-team
 ## What it includes
 
 - Skill: `skills/radical-pipelines/SKILL.md`.
-- Agents: `prompt-writer`, `spec-analyst`, `researcher`, `spec-writer`, `spec-reviewer`, `spec-consolidator`, `design-writer`, `design-reviewer`, `code-plan-writer`, `code-plan-reviewer`, `doc-plan-writer`, `doc-plan-reviewer`, `code-writer`, `code-reviewer`, `doc-writer`, and `doc-reviewer`. Consolidator agents for multi-lane phases 3 and 4 will ship when those modes are designed.
+- Agents: `spec-analyst`, `researcher`, `spec-writer`, `spec-reviewer`, `spec-consolidator`, `design-writer`, `design-reviewer`, `code-plan-writer`, `code-plan-reviewer`, `doc-plan-writer`, `doc-plan-reviewer`, `code-writer`, `code-reviewer`, `doc-writer`, and `doc-reviewer`. Phase 0 is the raw prompt — an input, not an agent-produced artifact — so it has no agent profile. Consolidator agents for multi-lane phases 3 and 4 will ship when those modes are designed.
 - Team templates: `radical-pipelines-spec`, `radical-pipelines-design`, `radical-pipelines-plan`, `radical-pipelines-code`, and `radical-pipelines-docs` as package-local source definitions. These templates are intended to be registered globally for `pi-teams`, not copied into every target repository. The spec, design, plan, code, and docs templates correspond to phases 1–5 of the autonomous workflow.
 - Bundled dependency resources loaded through `node_modules/...`: `pi-teams` and `@zenobius/pi-worktrees`.
 

--- a/.pi-extension/teams.yaml
+++ b/.pi-extension/teams.yaml
@@ -1,7 +1,6 @@
 # Phase teams shipped by the Radical Pipelines package. Later workflow wiring can
 # compose these templates into a full end-to-end pipeline team.
 radical-pipelines-spec:
-  - prompt-writer
   - spec-analyst
   - researcher
   - spec-writer

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This routes through the root-level Pi manifest (`package.json` at the repo root)
 The package installs:
 
 - the `radical-pipelines` skill;
-- phase agent profiles for the shipped phases and phase pairs: `prompt-writer`, `spec-analyst`, `researcher`, `spec-writer`, `spec-reviewer`, `spec-consolidator`, `design-writer`, `design-reviewer`, `code-plan-writer`, `code-plan-reviewer`, `doc-plan-writer`, `doc-plan-reviewer`, `code-writer`, `code-reviewer`, `doc-writer`, and `doc-reviewer`;
+- phase agent profiles for the shipped phases and phase pairs: `spec-analyst`, `researcher`, `spec-writer`, `spec-reviewer`, `spec-consolidator`, `design-writer`, `design-reviewer`, `code-plan-writer`, `code-plan-reviewer`, `doc-plan-writer`, `doc-plan-reviewer`, `code-writer`, `code-reviewer`, `doc-writer`, and `doc-reviewer` (phase 0 is the raw prompt, an input rather than an agent-produced artifact, so it has no agent profile);
 - the `radical-pipelines-spec`, `radical-pipelines-design`, `radical-pipelines-plan`, `radical-pipelines-code`, and `radical-pipelines-docs` pi-teams templates as package-local source definitions. These team templates are intended to be registered globally for `pi-teams`, not copied into every target repository. The full `radical-pipelines` team will ship alongside later workflow orchestration;
 - bundled `pi-teams`, `@zenobius/pi-worktrees`, and `@pi-agents/loop` Pi resources.
 

--- a/landing/demo.js
+++ b/landing/demo.js
@@ -7,16 +7,6 @@
 
   const phases = [
     {
-      phase: 'phase 0',
-      task: 'prompt-writer',
-      reads: [],
-      writes: ['prompt.md'],
-      runMs: 900,
-      sec: 4,
-      tokens: '1.1k',
-      treeIdx: [0],
-    },
-    {
       phase: 'phase 1',
       task: 'spec-writer',
       reads: ['prompt.md', 'requirements.md'],
@@ -81,6 +71,27 @@
       verdict: 'approved',
     },
     {
+      phase: 'phase 3',
+      task: 'doc-plan-writer',
+      reads: ['spec.md', 'design-doc.md'],
+      writes: ['doc-plan.md'],
+      runMs: 1100,
+      sec: 61,
+      tokens: '9.4k',
+      treeIdx: [8],
+    },
+    {
+      phase: 'phase 3',
+      task: 'doc-plan-reviewer',
+      reads: ['doc-plan.md', 'spec.md'],
+      writes: ['doc-plan-review-approved.md'],
+      runMs: 850,
+      sec: 33,
+      tokens: '5.6k',
+      treeIdx: [9],
+      verdict: 'approved',
+    },
+    {
       phase: 'phase 4',
       task: 'code-writer',
       reads: ['code-plan.md', 'design-doc.md'],
@@ -88,7 +99,7 @@
       runMs: 1900,
       sec: 412,
       tokens: '64.1k',
-      treeIdx: [8],
+      treeIdx: [10],
       bash: ['npm test', 'git commit -m "Add orchestrator (code-writer)"'],
     },
     {
@@ -99,7 +110,7 @@
       runMs: 1100,
       sec: 96,
       tokens: '14.3k',
-      treeIdx: [9],
+      treeIdx: [11],
       verdict: 'approved',
     },
     {
@@ -110,7 +121,7 @@
       runMs: 1200,
       sec: 89,
       tokens: '8.7k',
-      treeIdx: [10],
+      treeIdx: [12],
     },
     {
       phase: 'phase 5',
@@ -120,7 +131,7 @@
       runMs: 800,
       sec: 31,
       tokens: '4.9k',
-      treeIdx: [11],
+      treeIdx: [13],
       verdict: 'approved',
     },
   ];
@@ -134,6 +145,8 @@
     'design-doc-review-approved.md',
     'code-plan.md',
     'code-plan-review-approved.md',
+    'doc-plan.md',
+    'doc-plan-review-approved.md',
     'src/orchestrator.ts + test',
     'code-review-approved.md',
     'README.md, docs/',
@@ -260,10 +273,13 @@
       line(logEl, 'cc-bullet', '● Bash(git worktree add .pipelines/worktrees/issue-1234 -b issue/1234)');
       line(logEl, 'cc-sub done', '  ⎿  Preparing worktree (new branch \'issue/1234\')');
       line(logEl, 'cc-sub done', '  ⎿  HEAD is now at eda5064');
+      line(logEl, 'cc-sub done', '  ⎿  Captured issue #1234 → prompt.md (phase 0 · input)');
       line(logEl, 'cc-spacer', '');
 
       // Tree header
       pendingTree.forEach((f, i) => addPendingFile(f, i));
+      // Phase 0 is the raw prompt — an input, already in place, not produced by an agent.
+      commitPending(0);
 
       await sleep(reduced ? 50 : 800);
 
@@ -274,7 +290,7 @@
       line(
         logEl,
         'cc-summary',
-        '● Pipeline complete · 6 phases · 12 artifacts · 17m 8s total'
+        '● Pipeline complete · 6 phases · 14 artifacts · 18m 38s total'
       );
       autoScroll();
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -106,7 +106,7 @@
             </div>
             <ul class="hero-stats">
               <li><strong>6</strong><span>phases</span></li>
-              <li><strong>14</strong><span>agents shipped</span></li>
+              <li><strong>15</strong><span>agents shipped</span></li>
               <li><strong>2</strong><span>CLIs supported</span></li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary

While reviewing the site against the project's current state, the landing page had drifted, and a `prompt-writer` agent that never existed was referenced across the docs and the Pi team template. This reconciles both.

## Landing page

The Plan phase was split into two writer/reviewer pairs (`b242819`), but the demo only ever got the artifact *renames* — the doc-plan half was never added.

- **`landing/demo.js`** — add the Phase 3 doc-plan pair (`doc-plan-writer` → `doc-plan.md`, `doc-plan-reviewer` → `doc-plan-review-approved.md`) to the animated run and file tree; update the completion summary to **14 artifacts · 18m 38s**.
- **`landing/index.html`** — correct the hero stat to **15 agents shipped** (was stale at 14).

## `prompt-writer` phantom

Phase 0 is the raw prompt — an *input*, "already in place" (`SKILL.md:35`, both workflow docs) — not an agent-produced artifact, and the orchestrator spawns no agent for it. There is no `prompt-writer.md` profile, yet it was listed as a shipped agent. Removed from:

- `README.md` and `.pi-extension/README.md` agent lists (now 15 agents, with a note that Phase 0 has no agent profile).
- `.pi-extension/teams.yaml` — dropped from the `radical-pipelines-spec` team (it referenced a profile that never existed).
- `landing/demo.js` — the fake `Task(prompt-writer)` Phase 0 is replaced with an orchestrator capture step, with `prompt.md` shown as already-in-place input.

## Verification

- `demo.js` parses clean; all 14 file-tree rows map 1:1 to phase/commit indices.
- Both README agent lists now hold exactly 15 names, matching the 15 files in `.agents/agents/` and the hero stat.
- The only remaining `prompt-writer` reference is in `.pipelines/8-research.../design.md`, a historical record of a past run, intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)