### PR TITLE
Fix broken setup.md reference path in conventions loader

### DIFF
--- a/.agents/skills/radical-pipelines/reference/conventions/load.md
+++ b/.agents/skills/radical-pipelines/reference/conventions/load.md
@@ -23,6 +23,6 @@ This information is necessary to execute the pipelines correctly, so you must lo
 
 If all required conventions are available, continue the workflow unchanged.
 
-If one or more required conventions are missing, do not proceed with the pipeline. Read `reference/setup.md`, explain what is missing, and offer to run the setup flow.
+If one or more required conventions are missing, do not proceed with the pipeline. Read `setup.md`, explain what is missing, and offer to run the setup flow.
 
 If the owner declines setup, cancels, or leaves required answers unresolved, stop and clearly explain what is still missing.


### PR DESCRIPTION
## What

`reference/conventions/load.md` instructed the orchestrator to "Read `reference/setup.md`" when conventions are missing, but the setup flow actually lives at `reference/conventions/setup.md`. The link was a dead end.

Inside `conventions/`, sibling files are referenced by bare filename — `conventions/pi.md` already references the setup flow correctly as `` `setup.md` ``. This change makes `load.md` consistent with that convention.

## Change

- `load.md`: `` `reference/setup.md` `` → `` `setup.md` ``

## Why it matters

`load.md` is on the hot path of every workflow (conventions are loaded before any pipeline runs). When a required convention is missing, the orchestrator follows this link to offer setup — so the broken path directly affects the missing-conventions recovery flow.

No README update needed: the README documents the loader/setup files by their real locations and is unaffected by this internal path fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)