### PR TITLE
Derive pipeline lineage from artifact content; fix fork versioning and slug terminology

### DIFF
--- a/.agents/skills/radical-pipelines/reference/conventions/claude-code.md
+++ b/.agents/skills/radical-pipelines/reference/conventions/claude-code.md
@@ -20,7 +20,7 @@ All work for a pipeline happens inside a Claude Code worktree. Never modify file
 Branch names are derived automatically by `EnterWorktree` from the worktree name. Do not choose branch names independently and do not rename branches after the fact.
 
 - **Format:** `worktree-<pipeline-slug>`.
-- **Source of truth:** the `name` passed to `EnterWorktree` (equal to the pipeline slug) determines the branch.
+- **Source of truth:** the `name` passed to `EnterWorktree` (equal to the pipeline's versioned slug) determines the branch.
 
 ## Team spawning
 

--- a/.agents/skills/radical-pipelines/reference/conventions/load.md
+++ b/.agents/skills/radical-pipelines/reference/conventions/load.md
@@ -10,7 +10,7 @@ This information is necessary to execute the pipelines correctly, so you must lo
 
 | Convention        | What it covers                                                 | Required? |
 | ----------------- | -------------------------------------------------------------- | --------- |
-| Pipeline slug     | How to uniquely identify pipelines                             | Yes       |
+| Pipeline base slug | How to uniquely identify pipelines                            | Yes       |
 | Artifact folder   | Where to store the pipeline artifacts                          | Yes       |
 | Commit format     | How to write commits                                           | No        |
 | Issues            | Where to find the project issues and how to create/modify them | Yes       |

--- a/.agents/skills/radical-pipelines/reference/conventions/setup.md
+++ b/.agents/skills/radical-pipelines/reference/conventions/setup.md
@@ -29,11 +29,15 @@ Ask for the required information in a clear sequence, one convention at a time. 
 
 If a convention must be of a specific form due to the agentic coding tool's rules and does not require user input, simply inform the owner with a message explaining that convention and proceed to the next one.
 
-### Pipeline slug (required)
+### Pipeline base slug (required)
 
-The unique identifier for each pipeline. It is usually incorporated in the worktree name, the branch name, the artifacts folder name, etc, so it must be a valid filesystem and git identifier (lowercase, hyphens, no spaces).
+The unique identifier for a pipeline.
 
-The relationship between the issue and the pipeline slug must be deterministic: given an issue, the orchestrator must be able to enumerate every pipeline created for it by inspecting slugs alone.
+This convention defines the **pipeline base slug** — the `v1` form. A fork extends it with a `-v<N>` suffix, producing the **pipeline versioned slug**; every name derived from the slug inherits that suffix.
+
+This slug is incorporated into the worktree name, the branch name, the artifacts folder name, etc, so it must be a valid filesystem and git identifier (lowercase, hyphens, no spaces) — and must stay valid and unambiguous with `-v<N>` appended.
+
+The relationship between the issue and the slug must be deterministic: given an issue, the orchestrator must be able to enumerate every pipeline created for it by inspecting slugs alone. This does not require regenerating the full slug from the issue — only a reliable way to find an issue's pipelines.
 
 The slug format must also be robust against collisions between similar identifiers, so the pipelines of one issue can never be confused with those of another.
 

--- a/.agents/skills/radical-pipelines/reference/create-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/create-pipeline.md
@@ -2,15 +2,15 @@
 
 Creates a new pipeline through phase 0 — sets up the worktree and artifacts folder, writes `prompt.md`, and commits.
 
-Read `pipeline-versioning.md` first for the model — this is the first pipeline (`v1`), with no `/v<N>` branch suffix and no `pipeline.yml`.
+Read `pipeline-versioning.md` first for the model — this is the first pipeline (`v1`), so its versioned slug is just the pipeline base slug, with no `-v<N>` suffix.
 
 Before executing these steps, make sure you have loaded and verified the project conventions (see `conventions/load.md`).
 
 ## Steps
 
-### 1. Determine the pipeline slug
+### 1. Determine the pipeline base slug
 
-Generate the pipeline slug following the **Pipeline slug** convention.
+Generate the pipeline base slug following the **Pipeline base slug** convention. For `v1` this is also the pipeline's versioned slug.
 
 ### 2. Create and enter the worktree
 

--- a/.agents/skills/radical-pipelines/reference/fork-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/fork-pipeline.md
@@ -19,13 +19,15 @@ Then ask:
 
 If the owner has already specified any of them, skip the question.
 
-### 2. Compute the new pipeline version
+### 2. Compute the new version and pipeline versioned slug
 
 List the existing pipelines for this issue per `pipeline-versioning.md` ("Listing pipelines for an issue"). Find the highest existing `v<N>` among them; treat the first pipeline as `v1`. The new pipeline version is `v<N+1>`.
 
+The **pipeline versioned slug** is the **pipeline base slug** (the first pipeline's slug) with `-v<N+1>` appended, per `pipeline-versioning.md` ("Model").
+
 ### 3. Create the worktree and branch from the main branch
 
-Create the branch from the project's main branch per the **Branch names** convention, with `/v<N>` appended to the first pipeline's branch name. Then create and enter the worktree per the **Worktrees** convention.
+Create and enter the worktree for the pipeline versioned slug per the **Worktrees** convention; the branch is derived from it per the **Branch names** convention. Create the branch from the project's main branch.
 
 Always branch from the main branch — never from the parent pipeline's tip. The new pipeline must start with a clean working tree.
 
@@ -33,33 +35,21 @@ All work happens inside the new worktree.
 
 ### 4. Create the artifact folder
 
-Create the new pipeline's artifact folder per the **Artifact folder** convention applied to the slug, with `v<N>/` appended.
+Create the new pipeline's artifact folder per the **Artifact folder** convention applied to the pipeline versioned slug.
 
-### 5. Copy inherited phase folders from the parent
+### 5. Seed the inherited phase folders from the parent
 
-Determine the parent pipeline's worktree path per the **Worktrees** convention applied to the parent's slug and version.
+Copy only the phase folders being inherited — `0-prompt` up to and including the inherited phase agreed in step 1.
+
+Determine the parent pipeline's worktree path per the **Worktrees** convention applied to the parent's versioned slug.
 
 - **If the worktree exists**, copy directly: for every phase folder `0-prompt`, `1-spec`, … up to and including the inherited phase, `cp -r <parent-worktree>/<parent-artifact-folder>/<phase> <artifacts-folder>/<phase>`.
 - **If the worktree does not exist**, create a temporary worktree of the parent branch per the **Worktrees** convention, copy as above, then remove it.
 
-Copy only up to and including the inherited phase — do not bring later phases.
+### 6. Commit
 
-### 6. Write `pipeline.yml`
+Commit the seeded phase folders per the **Commit format** convention.
 
-Create `<artifacts-folder>/pipeline.yml` with exactly:
-
-```yaml
-forked_from:
-  pipeline: <parent-branch-name>
-  phase: <inherited-phase>
-```
-
-This file is immutable. Do not edit it again.
-
-### 7. Commit
-
-Commit the copied phase folders and `pipeline.yml` per the **Commit format** convention.
-
-### 8. Continue normal phase work
+### 7. Continue normal phase work
 
 The new pipeline is now a regular pipeline. Continue from the phase that follows the inherited phase, or revise the inherited phase, using the assisted or autonomous workflow as chosen by the owner.

--- a/.agents/skills/radical-pipelines/reference/pipeline-versioning.md
+++ b/.agents/skills/radical-pipelines/reference/pipeline-versioning.md
@@ -4,21 +4,17 @@ When the owner discards a pipeline or wants to try a different approach, the orc
 
 ## Model
 
-- **Pipeline slug** — per the **Pipeline slug** convention.
 - **Pipeline version** — `v1` is implicit for the first pipeline. Subsequent pipelines are `v2`, `v3`, …
-- **Branch name**:
-  - First pipeline: per the **Branch names** convention applied to the pipeline slug.
-  - Subsequent pipelines: append `/v<N>` to the first pipeline's branch name.
-- **Artifact folder** (`<artifacts-folder>`):
-  - First pipeline: per the **Artifact folder** convention applied to the pipeline slug.
-  - Subsequent pipelines: the first pipeline's artifact folder with `v<N>/` appended.
-- **Worktree**: one per pipeline, per the **Worktrees** convention.
+- **Pipeline base slug** — the version-less slug the **Pipeline base slug** convention produces; the shared stem of all of an issue's pipelines.
+- **Pipeline versioned slug** — one specific pipeline's identifier:
+  - First pipeline (`v1`): the pipeline base slug, unchanged — `v1` carries no suffix, because it is implicit.
+  - Subsequent pipelines (`v<N>`, N ≥ 2): the pipeline base slug with `-v<N>` appended.
 
 ### Key concepts
 
 - Every pipeline is created from the project's main branch — never from another pipeline's tip.
 - Inherited artifacts are copied as plain files into the new pipeline's artifact folder.
-- Git ancestry does not carry inheritance information; `pipeline.yml` does.
+- Lineage is not recorded anywhere. The tree is **derived** by comparing artifact content across the pipelines of an issue.
 
 ## Per-phase completion
 
@@ -37,62 +33,61 @@ A phase is complete when all of these are committed to the pipeline branch (same
 
 A pipeline's **completed phase** is the highest-numbered phase whose predicate is satisfied. Its **active phase** is the phase after the completed phase if any of that phase's artifacts have started appearing (in progress); otherwise the pipeline has no active phase.
 
-## `pipeline.yml`
+## Deriving lineage from artifact content
 
-Each pipeline forked from a previous one carries one file at the root of its artifact folder:
+Whether two pipelines share a phase is read directly from the artifacts: a phase folder is the same in two pipelines **if its content is byte-identical**, and git answers that with the folder's tree object SHA.
 
-```yaml
-forked_from:
-  pipeline: <parent-branch-name>
-  phase: <last-inherited-phase>
+```
+git rev-parse <ref>:<artifacts-folder>/<phase>
 ```
 
-1. The first pipeline has no `pipeline.yml`.
-2. `pipeline.yml` is written once by the orchestrator at fork time and is never modified.
-3. `forked_from.pipeline` is the parent's full branch name.
-4. `forked_from.phase` is the inherited phase — the highest-numbered phase folder copied from the parent (`0-prompt`, `1-spec`, `2-design-doc`, `3-plan`, `4-code`, `5-docs`).
+`<ref>` is wherever that pipeline's committed artifacts live: its **branch** if it still exists, otherwise the artifact-bearing repo's **main branch** (the fork's main in `artifacts-in-fork` mode, the project's main in `artifacts-in-repo` mode) — where a merged, branch-deleted pipeline is found per "Listing pipelines for an issue" (step 3). `<artifacts-folder>` is that pipeline's own folder, derived from its versioned slug. Tree SHAs are pure content hashes, so SHAs read through a branch and through main are directly comparable.
 
 ## Listing pipelines for an issue
 
 For a given issue, find every existing pipeline:
 
-1. **Derive a slug pattern** using the **Pipeline slug** convention that matches every slug referring to this issue.
-2. **Search branches** — local and remote — that match the **Branch names** convention and whose slug refers to this issue. Subsequent pipelines are picked up by the same pattern because their branch names append `/v<N>` to the first pipeline's branch.
+1. **Derive a search pattern** for the issue from the **Pipeline base slug** convention's deterministic relationship to the issue (the default keys on the issue id). It must match the pipeline base slug and any `-v<N>` extension of it.
+2. **Search branches** — local and remote — that match the **Branch names** convention for that slug pattern. Subsequent pipelines are picked up because their slugs (and therefore branch names) are the pipeline base slug with `-v<N>` appended.
 3. **Search artifact folders** in the **Artifact folder** location on the main branch of the artifact-bearing repository (the fork's main in `artifacts-in-fork` mode, the project's main in `artifacts-in-repo` mode, per the **Artifact storage** convention). A pipeline that was merged and had its branch deleted is only visible here.
 
-The first pipeline is the branch whose name has no `/v<N>` segment — equivalently, the branch whose artifact folder contains no `pipeline.yml`.
+Among the pipelines found, the pipeline base slug is the stem the others extend: that pipeline is `v1`, and each fork's slug is the base followed by `-v<N>`.
 
 ## Reconstructing the pipeline tree
 
-The tree is not stored. The orchestrator rebuilds it on demand:
+The tree is not stored. The orchestrator rebuilds it on demand from artifact content:
 
 1. List pipelines as described in "Listing pipelines for an issue".
-2. For each pipeline branch other than the first pipeline, read `pipeline.yml` from that branch without checkout:
+2. For each pipeline, compute the tree SHA of each phase folder it carries, in phase order (`0-prompt`, `1-spec`, …), stopping at the first phase folder it does not have:
    ```
-   git show <branch>:<artifacts-folder>/pipeline.yml
+   git rev-parse <ref>:<artifacts-folder>/<phase>
    ```
-3. Join on `forked_from.pipeline` to obtain parent edges. Group by parent for siblings.
+   `<ref>` is that pipeline's branch, or the artifact-bearing repo's main branch if its branch was deleted after merging (see "Deriving lineage from artifact content"). This yields, per pipeline, an ordered sequence of `(phase, SHA)` pairs.
+3. Build the tree as a trie over these sequences. A **node** is a `(phase, SHA)` pair: pipelines sharing the same SHA at a phase share that node. Pipelines stay on a common path while their SHAs match and branch apart at the first phase where they differ. `0-prompt` is identical across every pipeline of an issue (it is the issue), so it is always the shared root.
 
 ### Rendering
 
-Render the tree as plain ASCII using box-drawing characters (`├`, `└`, `│`, `─`) so it displays correctly in any surface. Each phase artifact is a node, labeled version-first as `v<N>: <phase>`. The root `0-prompt` carries no label — it's the shared starting point.
+Render the tree as plain ASCII using box-drawing characters (`├`, `└`, `│`, `─`) so it displays correctly in any surface. Each node is a phase artifact, labeled version-first as `v<N>: <phase>`. A node shared by several pipelines is labeled with the **lowest** version among them — the earliest pipeline carrying that artifact. The root `0-prompt` carries no label — it's the shared starting point.
 
 Example:
 
 ```
 0-prompt
-└── v1: 1-spec
-    ├── v1: 2-design-doc
-    │   └── v1: 3-plan → 4-code → 5-docs  [merged]
-    └── v2: 2-design-doc
-        ├── v2: 3-plan (in progress)
-        └── v3: 3-plan → 4-code (in progress)
+├── v1: 1-spec
+│   ├── v1: 2-design-doc
+│   │   └── v1: 3-plan → 4-code → 5-docs  [merged]
+│   └── v2: 2-design-doc
+│       ├── v2: 3-plan (in progress)
+│       └── v3: 3-plan → 4-code (in progress)
+└── v4: 1-spec
+    └── v4: 2-design-doc → 3-plan (in progress)
 ```
 
 Reading conventions:
 
 - A pipeline's **completed phase** is the deepest labeled node whose **Per-phase completion** predicate is satisfied. v1 has completed all five phases (and is merged); v2's deepest node is `3-plan` but the predicate is not yet satisfied, so its completed phase is `2-design-doc` and `3-plan` is its active phase; v3's completed phase is `3-plan` and `4-code` is its active phase.
-- What a pipeline **inherits** is every ancestor node up to the root. v2 inherits `v1: 1-spec` and `0-prompt`; v3 inherits everything v2 inherits plus `v2: 2-design-doc`.
-- A linear chain of phases owned by one pipeline with no further divergence may be compressed onto one line with `→` separators (as `v1: 3-plan → 4-code → 5-docs` above).
+- **Sibling nodes at the same phase have diverged** — their content differs. v1, v2, and v3 share one `1-spec` node, so all three carry the same spec. v4 has its own `1-spec` node branching straight off `0-prompt`: its spec differs from v1's (for instance, v4 forked from v1 and revised the spec).
+- What a pipeline **shares** is every ancestor node up to the root; those phases are byte-identical to the pipelines it shares them with. v2 shares `v1: 1-spec` and `0-prompt`; v3 shares everything v2 shares plus `v2: 2-design-doc`; v4 shares only `0-prompt` with the rest.
+- A linear chain of phases held by one pipeline with no further divergence may be compressed onto one line with `→` separators (as `v1: 3-plan → 4-code → 5-docs` above).
 - `(in progress)` annotates the trailing node when its **Per-phase completion** predicate isn't yet satisfied. It signals that work has started but not finished.
 - `[merged]` annotates a pipeline that has been merged into the project's main branch. Phase completion can be inferred from the predicate; "merged into main" cannot.

--- a/.agents/skills/radical-pipelines/reference/pipeline-versioning.md
+++ b/.agents/skills/radical-pipelines/reference/pipeline-versioning.md
@@ -14,7 +14,7 @@ When the owner discards a pipeline or wants to try a different approach, the orc
 
 - Every pipeline is created from the project's main branch — never from another pipeline's tip.
 - Inherited artifacts are copied as plain files into the new pipeline's artifact folder.
-- Lineage is not recorded anywhere. The tree is **derived** by comparing artifact content across the pipelines of an issue.
+- Lineage is **derived** by comparing artifact content across the pipelines of an issue.
 
 ## Per-phase completion
 
@@ -55,7 +55,7 @@ Among the pipelines found, the pipeline base slug is the stem the others extend:
 
 ## Reconstructing the pipeline tree
 
-The tree is not stored. The orchestrator rebuilds it on demand from artifact content:
+The orchestrator rebuilds the tree on demand from artifact content:
 
 1. List pipelines as described in "Listing pipelines for an issue".
 2. For each pipeline, compute the tree SHA of each phase folder it carries, in phase order (`0-prompt`, `1-spec`, …), stopping at the first phase folder it does not have:


### PR DESCRIPTION
## Summary

Reworks how forked pipelines are versioned and how their lineage is determined, driven by two concrete problems found while testing:

1. **A forked-and-revised spec showed as identical to its parent.** Lineage was declared in an immutable `pipeline.yml`, but artifacts are mutable — so the declaration silently drifted from reality.
2. **Forks were created with an improvised `+v2` separator** because the documented `/v<N>` branch suffix can't be a worktree directory name (v1's worktree already occupies the base path).

### Changes

- **Eliminate `pipeline.yml`; derive lineage from artifact content.** Two pipelines share a phase iff the phase folder's git **tree SHA** matches (`git rev-parse <ref>:<artifacts-folder>/<phase>`). Sharing vs. divergence is read straight from the artifacts, so a revised phase can never be mistaken for an unchanged one. The pipeline tree is rebuilt on demand as a trie over each pipeline's `(phase, SHA)` sequence.
- **Move the version into the slug as `-v<N>`.** Both supported tools derive the branch and worktree from the slug, and a slug must be filesystem-safe — so `/` was never viable. `-v<N>` keeps each version a sibling directory/branch. Fork detection is structural (forks are `<base>-v<N>`), robust even when a base slug itself ends in `-v<digits>`.
- **Clarify terminology.** Introduces **pipeline base slug** (version-less, per issue) vs. **pipeline versioned slug** (per pipeline; base for v1, base + `-v<N>` for forks), and renames the convention to **Pipeline base slug**.
- **Generalize SHA lookup to `<ref>`** so merged, branch-deleted pipelines (visible only via artifact folders on main) are reconstructed correctly.
- Define the new pipeline's versioned slug explicitly in the fork procedure (closing a gap where the term was referenced but never constructed).

### Files

`reference/pipeline-versioning.md`, `reference/fork-pipeline.md`, `reference/create-pipeline.md`, and the `conventions/` docs (`setup.md`, `load.md`, `claude-code.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)