### PR TITLE
Add resume-pipeline.md reference for resuming in-progress pipelines

### DIFF
--- a/.agents/skills/radical-pipelines/reference/create-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/create-pipeline.md
@@ -2,10 +2,6 @@
 
 Creates a new pipeline through phase 0 — sets up the worktree and artifacts folder, writes `prompt.md`, and commits.
 
-Read `pipeline-versioning.md` first for the model — this is the first pipeline (`v1`), so its versioned slug is just the pipeline base slug, with no `-v<N>` suffix.
-
-Before executing these steps, make sure you have loaded and verified the project conventions (see `conventions/load.md`).
-
 ## Steps
 
 ### 1. Determine the pipeline base slug

--- a/.agents/skills/radical-pipelines/reference/fork-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/fork-pipeline.md
@@ -2,10 +2,6 @@
 
 Creates a new pipeline for an issue by forking from a parent pipeline at a chosen phase.
 
-Read `pipeline-versioning.md` first for the model.
-
-Before executing these steps, make sure project conventions are loaded (see `conventions/load.md`).
-
 ## Steps
 
 ### 1. Identify the parent pipeline and inherited phase

--- a/.agents/skills/radical-pipelines/reference/resume-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/resume-pipeline.md
@@ -1,0 +1,42 @@
+# Resuming a Pipeline
+
+Resumes an in-progress pipeline.
+
+## Steps
+
+### 1. Cancel any leftover health monitor
+
+Cancel any health-monitor loop still registered for this pipeline's slug, per the **Health monitoring** convention. Leftover loops from a previous session persist and must be cancelled before the workflow launches a new one for the same pipeline (see `health-monitoring.md`).
+
+### 2. Re-attach to the branch and worktree
+
+All subsequent work happens inside the pipeline's worktree, per the **Worktrees** convention. Re-attach to the existing worktree for the pipeline's versioned slug:
+
+- **If the worktree exists**, re-enter it per the **Worktrees** convention.
+- **If the worktree is gone but the branch exists**, recreate the worktree from the existing branch per the **Worktrees** convention.
+
+### 3. Verify on-disk state against the completion predicate
+
+Read the actual files on the branch and confirm the state against the **Per-phase completion** predicate in `pipeline-versioning.md`:
+
+- Confirm the **completed phase**'s predicate is present and committed.
+- For the **active phase** (if any), read its latest artifact end-to-end to establish exactly how far it got and why its predicate is not yet met.
+
+### 4. Determine the resume point and restart a partial active phase
+
+If the pipeline has an **active phase** (partially complete), that is the resume point. Otherwise the resume point is the phase **after** the completed phase, the worktree is already clean, and you continue to step 6.
+
+The workflow phase references assume a phase starts fresh, so a partially-complete active phase must be **rolled back to a clean state** before the workflow re-runs it.
+
+Confirm with the owner first:
+
+1. Tell the owner plainly that the active phase will be **restarted and its state reset**: its commits on this branch will be reverted and any uncommitted changes in the worktree discarded, so the phase starts clean. The completed phase and every earlier phase are left untouched.
+2. **Ask the owner to confirm.** If they decline, do not roll anything back — stop and offer alternatives, for example forking a new pipeline from the completed phase per `fork-pipeline.md`, which leaves this pipeline's partial state intact.
+3. On confirmation, **revert the active phase's commits** so the branch tip returns to the completed-phase state.
+   - Reverting adds inverse commits rather than rewriting history, so a branch already on the remote needs no force-update.
+   - Then discard any uncommitted changes so the worktree is clean.
+   - The active phase folder is now gone from the tip: the pipeline's completed phase is unchanged and it has no active phase.
+
+---
+
+Resume ends here. Return to `work-on-an-issue.md`.

--- a/.agents/skills/radical-pipelines/reference/resume-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/resume-pipeline.md
@@ -19,7 +19,7 @@ All subsequent work happens inside the pipeline's worktree, per the **Worktrees*
 
 Read the actual files on the branch and confirm the state against the **Per-phase completion** predicate in `pipeline-versioning.md`:
 
-- Confirm the **completed phase**'s predicate is present and committed.
+- Confirm the **completed phase**'s required artifacts are present and committed.
 - For the **active phase** (if any), read its latest artifact end-to-end to establish exactly how far it got and why its predicate is not yet met.
 
 ### 4. Determine the resume point and restart a partial active phase

--- a/.agents/skills/radical-pipelines/reference/resume-pipeline.md
+++ b/.agents/skills/radical-pipelines/reference/resume-pipeline.md
@@ -24,7 +24,7 @@ Read the actual files on the branch and confirm the state against the **Per-phas
 
 ### 4. Determine the resume point and restart a partial active phase
 
-If the pipeline has an **active phase** (partially complete), that is the resume point. Otherwise the resume point is the phase **after** the completed phase, the worktree is already clean, and you continue to step 6.
+If the pipeline has an **active phase** (partially complete), that is the resume point. Otherwise the resume point is the phase **after** the completed phase; the worktree is already clean, so skip the rollback below.
 
 The workflow phase references assume a phase starts fresh, so a partially-complete active phase must be **rolled back to a clean state** before the workflow re-runs it.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ CLIs:
 
 Entry points:
 
-- **Work on an issue** — identify an existing issue and create or run a pipeline for it through a workflow.
+- **Work on an issue** — identify an existing issue, then create a new pipeline or act on one that already exists. The orchestrator lists the issue's existing pipelines, reconstructs their version tree, and determines each one's completed and active phase per `reference/pipeline-versioning.md`. When matches exist, the owner can **resume** an in-progress pipeline — re-attach to its branch and worktree, verify on-disk state against the per-phase completion predicate, and continue from the right phase, restarting a partially-complete phase after owner confirmation (see `reference/resume-pipeline.md`) — or **fork** a new pipeline from an existing one (see `reference/fork-pipeline.md`). The chosen pipeline then runs through a workflow.
 - **Manage issues** — create or modify a well-formed issue through a short Q&A between the orchestrator and the owner. The issue records the desired *outcome* (the always-present Goal) plus only the constraints, context, or open assumptions the owner already holds; it stays a WHAT-only prompt because requirements, design, and the task plan are produced by later phases, and the agents do their own research. The orchestrator tells the owner that under-specifying is safe and surfaces owner hypotheses as "directions to explore," not requirements. The issue body doubles as the phase-0 prompt. See `reference/manage-issues.md`.
 
 Workflows:


### PR DESCRIPTION
Closes #56.

## What

Adds `reference/resume-pipeline.md`, the previously-missing control file that `work-on-an-issue.md` step 2 routes to when the owner chooses to **resume** a matching in-progress pipeline. Until now that link was a dead end.

Resume is a sub-routine of "Work on an issue": by the time it runs, step 2 has already listed the issue's pipelines, reconstructed the tree, and determined the chosen pipeline's completed and active phase. This file picks up that specific pipeline and continues it, then hands control back to `work-on-an-issue.md`.

## The four steps

1. **Cancel any leftover health monitor** — a loop from a previous session persists and must be cancelled before the workflow launches a new one (per the **Health monitoring** convention / `health-monitoring.md`).
2. **Re-attach to the branch and worktree** — re-enter the existing worktree, or recreate it from the branch if it's gone (per the **Worktrees** convention).
3. **Verify on-disk state against the completion predicate** — read the actual artifacts, don't trust prior reports (per `pipeline-versioning.md`).
4. **Determine the resume point and restart a partial active phase** — the active phase if one exists, else the phase after the completed phase. A partially-complete active phase is rolled back to a clean state *after explicit owner confirmation* by **reverting** its commits (no history rewrite, so a pushed branch needs no force-update) and discarding uncommitted changes; declining offers forking instead.

## Related cleanup

Routed through the single-orchestrator model, the "load conventions / read the model first" lines are only needed in the entry points (`work-on-an-issue.md`, `manage-issues.md`) that actually do the loading. Removed the duplicated copies from the sub-routines `create-pipeline.md` and `fork-pipeline.md` so they match `resume-pipeline.md`.

## Docs

Per `AGENTS.md`, expanded the README "Work on an issue" entry point to document resume (and the previously-undocumented fork), both hanging off the existing-pipeline detection in `pipeline-versioning.md`. Merge/review/close are intentionally not mentioned — those reference files don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)