### PR TITLE
Stop spec phase from leaking implementation details

### DIFF
--- a/.agents/agents/researcher.md
+++ b/.agents/agents/researcher.md
@@ -37,4 +37,4 @@ If the spec-analyst asks you to write findings to a file in the artifacts folder
 - **Say "I don't know" when you don't.** A wrong answer is worse than no answer. Note what "needs investigation" so the spec-analyst can decide next steps.
 - **Flag ambiguities.** Questions often have multiple valid answers, and picking one silently hides trade-offs the spec-analyst needs to see.
 - **Be thorough but concise.** Unnecessary padding buries the signal and wastes context.
-- **Surface evidence, not designs.** Report constraints, feasibility, and existing patterns. Do not propose architectures or designs.
+- **Surface evidence, not decisions.** Existing patterns, constraints, trade-offs, and what's achievable are findings worth reporting. Choosing what to require or how to build it — the requirement, the architecture, the design — is the job of the agent you report to, not yours.

--- a/.agents/agents/spec-analyst.md
+++ b/.agents/agents/spec-analyst.md
@@ -45,7 +45,7 @@ Cover these areas strategically — not as a checklist, and not always in this o
 - **Integration** — what existing systems this must work with.
 - **Data** — structures, lifecycle, persistence.
 
-If a question would benefit from codebase investigation, tell the researcher to research it before answering. Suggest options when the researcher's answer reveals uncertainty.
+If a question would benefit from codebase investigation, tell the researcher to research it before answering.
 
 Track exclusions as they surface, and note the out-of-scope candidates in the consolidated requirements.
 
@@ -53,10 +53,10 @@ Track exclusions as they surface, and note the out-of-scope candidates in the co
 
 At any point during clarification, you can ask the researcher to investigate specific topics:
 
-- Existing patterns in the codebase
-- How similar features are implemented
-- Technical feasibility of an approach
-- What libraries or utilities already exist
+- How the relevant part of the app currently behaves
+- Existing patterns and conventions the feature must fit
+- Whether the desired behavior is achievable, and what constrains it
+- Prior art or reference docs describing the expected behavior
 
 When requesting research, be specific about what you need to know and why. Append the researcher's findings under a `## Research` section in `<artifacts-folder>/1-spec/requirements.md`.
 


### PR DESCRIPTION
Closes #64

## Problem

The spec phase was producing requirements that carried implementation suggestions. The leak entered at the source: the **spec-analyst** asked implementation-flavored questions → the **researcher** answered with a worked solution → the analyst recorded it as fact → a design grew inside the requirements.

The fix targets where the leak *enters*, not where it surfaces — reframing the positive pulls rather than piling on prohibitions.

## Changes

**`spec-analyst.md`**
- **Research-request menu** reframed from implementation-flavored ("how similar features are implemented", "feasibility of an approach") toward behavior and constraints ("how the relevant part of the app currently behaves", "whether the desired behavior is achievable, and what constrains it"). "Feasibility of *an approach*" was the line that turned "is this possible?" into "here's the implementation."
- Dropped **"Suggest options when the researcher's answer reveals uncertainty"**, which fought the existing "Do NOT propose solutions or design" rule.

**`researcher.md`**
- Recast "Surface evidence, not designs" → **"Surface evidence, not decisions"**: defines the researcher's boundary as report-vs-decide, keeps the concrete fence (requirement / architecture / design), and adds trade-offs. Phrased to be phase-neutral so it holds for the design-phase researcher planned in #75 — no "later phase" assumption that would withhold the implementation-level evidence the design phase needs.

## Note for #75

The researcher still hardcodes references to `spec-analyst` (it is only paired with spec-analyst today). Those will need generalizing to "the analyst" when #75 adds a design-doc analyst — deliberately left out of scope here since it's a wiring change, not a wording one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)