### PR TITLE
Configure per-agent models in `.rp.md`

### DIFF
--- a/.rp.md
+++ b/.rp.md
@@ -69,6 +69,27 @@ Created automatically by `EnterWorktree`: `worktree-<pipeline-slug>`
 
 Use `TeamCreate`.
 
+### Agent models
+
+| Agent                   | model  |
+| ----------------------- | ------ |
+| `spec-analyst`          | fable  |
+| `spec-researcher`       | opus   |
+| `spec-writer`           | opus   |
+| `spec-reviewer`         | fable  |
+| `design-doc-analyst`    | fable  |
+| `design-doc-researcher` | opus   |
+| `design-doc-writer`     | opus   |
+| `design-doc-reviewer`   | fable  |
+| `code-plan-writer`      | opus   |
+| `code-plan-reviewer`    | fable  |
+| `doc-plan-writer`       | opus   |
+| `doc-plan-reviewer`     | opus   |
+| `code-writer`           | sonnet |
+| `code-reviewer`         | fable  |
+| `doc-writer`            | opus   |
+| `doc-reviewer`          | opus   |
+
 ### Health monitoring
 
 Use the bundled `/loop` skill.


### PR DESCRIPTION
## What

Add an `### Agent models` block to this repo's dogfood `.rp.md`, pinning a model per spawned pipeline agent.

## Why

With a top-tier `fable` model now available alongside `opus`/`sonnet`, each agent can be matched to the capability its role actually needs — concentrating the strongest model where errors are most expensive and least recoverable, and using cheaper tiers where the work is backstopped or highly parallel.

The tiering follows decision-ownership and blast radius:

- **fable** — the deciders (`spec-analyst`, `design-doc-analyst`) and the adversarial reviewers (`spec-reviewer`, `design-doc-reviewer`, `code-plan-reviewer`, `code-reviewer`), where a miss propagates furthest.
- **opus** — the evidence-and-synthesis backbone: the researchers (their findings are the compounding foundation, only partially backstopped by the analyst) and all the writers/doc reviewers.
- **sonnet** — `code-writer`, the one massively-parallel role, backstopped by the fable `code-reviewer`.

## Notes

- Touches only `.rp.md` (the dogfood conventions file), which is outside the changeset `changedFilePatterns` — no changeset required.
- Documentation only for now: nothing reads the table until each agent's frontmatter / the per-tool native model mapping is wired up (and the real `fable` model-id string is filled in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)